### PR TITLE
Feature: Added option to use exsiting secret

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/requirements.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/requirements.yaml
@@ -1,10 +1,10 @@
 dependencies:
   - name: splunk-kubernetes-logging
-    version: 1.0.0
+    version: 1.1.0
     repository: stable
   - name: splunk-kubernetes-objects
-    version: 1.0.0
+    version: 1.1.0
     repository: stable
   - name: splunk-kubernetes-metrics
-    version: 1.0.0
+    version: 1.1.0
     repository: stable

--- a/helm-chart/splunk-kubernetes-logging/templates/daemonset.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/daemonset.yaml
@@ -52,7 +52,11 @@ spec:
           - name: SPLUNK_HEC_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ template "splunk-kubernetes-logging.fullname" . }}
+                {{- if .Values.existingSecret -}}
+                  name: {{ .Values.existingSecret -}}
+                {{- else -}}
+                  name: {{ template "splunk-kubernetes-logging.fullname" . }}
+                {{- end -}}
                 key: splunk_hec_token
         resources:
 {{ toYaml .Values.resources | indent 10 }}
@@ -86,4 +90,8 @@ spec:
           name: {{ template "splunk-kubernetes-logging.fullname" . }}
       - name: secrets
         secret:
-          secretName: {{ template "splunk-kubernetes-logging.fullname" . }}
+          {{- if .Values.existingSecret -}}
+             secretName: {{ .Values.existingSecret -}}
+          {{- else -}}
+            secretName: {{ template "splunk-kubernetes-logging.fullname" . }}
+          {{- end -}}

--- a/helm-chart/splunk-kubernetes-logging/templates/secret.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/secret.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.secret.create -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "splunk-kubernetes-logging.fullname" . }}
+  name: {{  .Values.secret.name | default template "splunk-kubernetes-logging.fullname" . }}
   labels:
     app: {{ template "splunk-kubernetes-logging.name" . }}
     chart: {{ template "splunk-kubernetes-logging.chart" . }}
@@ -21,3 +22,4 @@ data:
   {{- with or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile }}
   hec_ca_file: {{ . | b64enc }}
   {{- end }}
+{{- end -}}

--- a/helm-chart/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-kubernetes-logging/values.yaml
@@ -54,6 +54,8 @@ splunk:
     #       The file will be stored as a secret in kubernetes.
     caFile:
 
+#use existing K8s Secret
+existingSecret:
 
 # Directory where to read journald logs.
 journalLogPath: /run/log/journal

--- a/helm-chart/splunk-kubernetes-metrics/Chart.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 1.0.0
+version: 1.1.0
 name: splunk-kubernetes-metrics
 description: Collect metrics with Splunk.
 home: https://github.com/splunk/splunk-connect-for-kubernetes/tree/master/helm-chart/charts/splunk-kubernetes-metrics

--- a/helm-chart/splunk-kubernetes-metrics/templates/deployment.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/deployment.yaml
@@ -78,7 +78,7 @@ spec:
             - name: SPLUNK_HEC_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "splunk-kubernetes-metrics.fullname" . }}
+                  name: {{ .Values.secret.name | default template "splunk-kubernetes-metrics.fullname" . -}}        
                   key: splunk_hec_token
           resources:
 {{ toYaml .Values.resources.sidecar | indent 12 }}
@@ -94,4 +94,4 @@ spec:
           name: {{ template "splunk-kubernetes-metrics.fullname" . }}
       - name: secrets
         secret:
-          secretName: {{ template "splunk-kubernetes-metrics.fullname" . }}
+          secretName: {{ .Values.secret.name | default template "splunk-kubernetes-metrics.fullname" . -}}

--- a/helm-chart/splunk-kubernetes-metrics/templates/secret.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/secret.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.secret.create -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "splunk-kubernetes-metrics.fullname" . }}
+  name: {{ .Values.secret.name | default template "splunk-kubernetes-metrics.fullname" . }}
   labels:
     app: {{ template "splunk-kubernetes-metrics.name" . }}
     chart: {{ template "splunk-kubernetes-metrics.chart" . }}
@@ -21,3 +22,4 @@ data:
   {{- with or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile }}
   hec_ca_file: {{ . | b64enc }}
   {{- end }}
+{{- end -}}

--- a/helm-chart/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/values.yaml
@@ -72,6 +72,10 @@ splunk:
     #       The file will be stored as a secret in kubernetes.
     caFile:
 
+# Create or use existing secret if name is empty default name is used
+secret:
+  create: true
+  name:
 
 image:
   heapsterTag: v1.5.1

--- a/helm-chart/splunk-kubernetes-objects/templates/deployment.yaml
+++ b/helm-chart/splunk-kubernetes-objects/templates/deployment.yaml
@@ -60,8 +60,8 @@ spec:
           - name: SPLUNK_HEC_TOKEN
             valueFrom:
               secretKeyRef:
-                name: {{ template "splunk-kubernetes-objects.fullname" . }}
-                key: splunk_hec_token
+                  name: {{  .Values.secret.name | default template "splunk-kubernetes-objects.fullname" . -}}
+                  key: splunk_hec_token
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
@@ -80,7 +80,7 @@ spec:
           name: {{ template "splunk-kubernetes-objects.fullname" . }}
       - name: secrets
         secret:
-          secretName: {{ template "splunk-kubernetes-objects.fullname" . }}
+          secretName: {{  .Values.secret.name | default template "splunk-kubernetes-objects.fullname" . -}}
       {{- if .Values.checkpointFile.volume }}
       - name: checkpoints
 {{ toYaml .Values.checkpointFile.volume | indent 8 }}

--- a/helm-chart/splunk-kubernetes-objects/templates/secret.yaml
+++ b/helm-chart/splunk-kubernetes-objects/templates/secret.yaml
@@ -1,7 +1,8 @@
+{{- if .Values.secret.create -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "splunk-kubernetes-objects.fullname" . }}
+  name: {{  .Values.secret.name | default template "splunk-kubernetes-objects.fullname" . }}
   labels:
     app: {{ template "splunk-kubernetes-objects.name" . }}
     chart: {{ template "splunk-kubernetes-objects.chart" . }}
@@ -30,3 +31,4 @@ data:
   {{- with .Values.kubernetes.caFile }}
   k8s_ca_file: {{ . | b64enc }}
   {{- end }}
+{{- end -}}

--- a/helm-chart/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-kubernetes-objects/values.yaml
@@ -162,6 +162,10 @@ splunk:
     # The path to a directory containing CA certificates which are in PEM format.
     caPath:
 
+# Create or use existing secret if name is empty default name is used
+secret:
+  create: true
+  name:
 
 image:
   tag: 1.0.0


### PR DESCRIPTION
Added option that an existing Kubernetes secret can be used instead of creating a new one with the Helm Deployment. 