### PR TITLE
Adding an optional clusterName value in order to have the ability to filter by a cluster_name field in splunk.

### DIFF
--- a/helm-chart/splunk-kubernetes-logging/examples/use_logs.yaml
+++ b/helm-chart/splunk-kubernetes-logging/examples/use_logs.yaml
@@ -3,6 +3,8 @@ splunk:
     token: 11111111-2222-3333-4444-555555555555
     host: 12.34.56.78
 
+clusterName: "MY_CLUSTER"
+
 logs:
   # we want to read logs for `kube-apiserver` from a log file other then from the container logs
   kube-apiserver:

--- a/helm-chart/splunk-kubernetes-logging/templates/_helpers.tpl
+++ b/helm-chart/splunk-kubernetes-logging/templates/_helpers.tpl
@@ -92,6 +92,9 @@ def extract_container_info:
   | .namespace = $parts[1]
   | .container_name = ($cparts[:-1] | join("-"))
   | .container_id = ($cparts[-1] | rtrimstr(".log"))
+  {{- if .Values.clusterName }}
+  | .cluser_name = "{{ .Values.clusterName }}"
+  {{- end }}
   | .;
   
 .record | extract_container_info | .sourcetype = (find_sourcetype(.pod; .container_name) // "kube:container:\(.container_name)")

--- a/helm-chart/splunk-kubernetes-logging/templates/_helpers.tpl
+++ b/helm-chart/splunk-kubernetes-logging/templates/_helpers.tpl
@@ -93,7 +93,7 @@ def extract_container_info:
   | .container_name = ($cparts[:-1] | join("-"))
   | .container_id = ($cparts[-1] | rtrimstr(".log"))
   {{- if .Values.clusterName }}
-  | .cluser_name = "{{ .Values.clusterName }}"
+  | .cluster_name = "{{ .Values.clusterName }}"
   {{- end }}
   | .;
   

--- a/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
@@ -229,7 +229,7 @@ data:
           container_name
           container_id
           {{- if .Values.clusterName }}
-          cluser_name
+          cluster_name
           {{- end }}
         </fields>
         <buffer>

--- a/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
@@ -228,6 +228,9 @@ data:
           namespace
           container_name
           container_id
+          {{- if .Values.clusterName }}
+          cluser_name
+          {{- end }}
         </fields>
         <buffer>
           @type memory

--- a/helm-chart/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-kubernetes-logging/values.yaml
@@ -16,6 +16,10 @@ global:
       insecureSSL: false
 
 
+# If clusterName is set, a cluster_name field will be added to the log output
+clusterName:
+
+
 # logLevel is to set log level of the Splunk log collector. Avaiable values are:
 # * trace
 # * debug

--- a/manifests/splunk-kubernetes-logging/configMap.yaml
+++ b/manifests/splunk-kubernetes-logging/configMap.yaml
@@ -219,6 +219,7 @@ data:
           namespace
           container_name
           container_id
+          cluster_name
         </fields>
         <buffer>
           @type memory


### PR DESCRIPTION
Logs being collected into splunk will have a new field called "cluster_name". 