### PR TITLE
Add basic support for OpenShift as a deploy target

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/examples/mini.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/examples/mini.yaml
@@ -1,13 +1,30 @@
 global:
   splunk:
     hec:
-      token: 7fbefa0b-8c06-4a62-a54b-0fa69c016988
-      host: 45.209.241.112
+      token: BF7FBF5F-47A0-457D-A191-7CD6A25DA26C
+      host: hec.splunk.rackspace.com
       port: 8088
-      indexName: main
+      indexName: rax_saac_temp_30
+  openshift: true
+
+resources:
+  limit:
+    memory: 300m
+
+rbac:
+  create: true
 
 
-splunk-kubernetes-metrics:
-  splunk:
-    hec:
-      indexName: my-metrics-index
+logging:
+  enabled: true
+
+splunk-kubernetes-logging:
+  serviceAccount:
+    create: true
+    name: splunk
+
+objects:
+  enabled: false
+
+metrics:
+  enabled: false

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -9,6 +9,7 @@
 #   splunk:
 #     # HEC related configurations
 #     hec:
+#   openshift: boolean # trigger a few extra configuration items required to run in OpenShift
 #
 # For other configurations for sub-charts, please check their values.yaml for details.
 

--- a/helm-chart/splunk-kubernetes-logging/templates/daemonset.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/daemonset.yaml
@@ -56,6 +56,10 @@ spec:
                 key: splunk_hec_token
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        {{- if .Values.global.openshift }}
+        securityContext:
+          privileged: true
+        {{ end -}}
         volumeMounts:
         - name: varlog
           mountPath: /var/log
@@ -70,6 +74,13 @@ spec:
         - name: secrets
           mountPath: /fluentd/etc/splunk
           readOnly: true
+      {{- if .Values.global.openshift }}
+      securityContext: {}
+      {{ end -}}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccount: {{ .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{ end -}}
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog

--- a/helm-chart/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-kubernetes-logging/values.yaml
@@ -24,6 +24,12 @@ global:
 # * error
 logLevel:
 
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
 
 # Local splunk configurations
 splunk:


### PR DESCRIPTION
So... its not working for some reason but I'm not getting any errors, but this should _technically_ work, as its the steps i used to make another logging daemonset work.
[mini.yaml.txt](https://github.com/splunk/splunk-connect-for-kubernetes/files/2765136/mini.yaml.txt)
[logs.txt](https://github.com/splunk/splunk-connect-for-kubernetes/files/2765141/logs.txt)


So procedure wise what I did:

* Clone this repo
* Update chart to support the conditionals
* Create the mini.yaml
* Rebuild chart locally
* Run helm install
```
helm template --name my-release -f helm-chart/splunk-connect-for-kubernetes/examples/mini.yaml build/splunk-connect-for-kubernetes-1.0.1.tgz  | oc create -f -
```

attached logs.txt is from an `oc logs po/my-release-splunk-kubernetes-logging-99zvp`



