### PR TITLE
Make systemd components persist a position file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ manifests: connect-chart
 	   --set global.splunk.hec.host=MY-SPLUNK-HOST \
 	   --set global.splunk.hec.token=MY-SPLUNK-TOKEN \
 	   --set global.splunk.hec.insecureSSL=true \
+	   --set splunk-kubernetes-logging.fullnameOverride="splunk-kubernetes-logging" \
+	   --set splunk-kubernetes-metrics.fullnameOverride="splunk-kubernetes-metrics" \
+	   --set splunk-kubernetes-objects.fullnameOverride="splunk-kubernetes-objects" \
 	   --set splunk-kubernetes-objects.kubernetes.insecureSSL=true \
 	   $$(ls build/splunk-connect-for-kubernetes-*.tgz) \
 	   | ruby tools/gen_manifest.rb manifests

--- a/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
@@ -117,6 +117,7 @@ data:
       <storage>
         @type local
         persistent true
+        path /var/log/splunkd-fluentd-journald-{{ $name }}.pos.json
       </storage>
       <entry>
         field_map {"MESSAGE": "log", "_SYSTEMD_UNIT": "source"}

--- a/manifests/splunk-kubernetes-logging/configMap.yaml
+++ b/manifests/splunk-kubernetes-logging/configMap.yaml
@@ -68,6 +68,7 @@ data:
       <storage>
         @type local
         persistent true
+        path /var/log/splunkd-fluentd-journald-docker.pos.json
       </storage>
       <entry>
         field_map {"MESSAGE": "log", "_SYSTEMD_UNIT": "source"}
@@ -85,6 +86,7 @@ data:
       <storage>
         @type local
         persistent true
+        path /var/log/splunkd-fluentd-journald-kubelet.pos.json
       </storage>
       <entry>
         field_map {"MESSAGE": "log", "_SYSTEMD_UNIT": "source"}

--- a/manifests/splunk-kubernetes-metrics/configMap.yaml
+++ b/manifests/splunk-kubernetes-metrics/configMap.yaml
@@ -18,6 +18,7 @@ data:
       node_name "#{ENV['SPLUNK_HEC_HOST']}"
       use_rest_client_ssl true
       cluster_name cluster_name
+      interval 15s
     </source>
     <filter kube.**>
       @type record_modifier

--- a/manifests/splunk-kubernetes-metrics/configMapMetricsAggregator.yaml
+++ b/manifests/splunk-kubernetes-metrics/configMapMetricsAggregator.yaml
@@ -15,6 +15,8 @@ data:
     <source>
       @type kubernetes_metrics_aggregator
       tag kube.*
+      cluster_name cluster_name
+      interval 15s
     </source>
     <filter kube.**>
       @type record_modifier

--- a/manifests/splunk-kubernetes-metrics/deploymentMetricsAggregator.yaml
+++ b/manifests/splunk-kubernetes-metrics/deploymentMetricsAggregator.yaml
@@ -21,9 +21,6 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       serviceAccountName: splunk-kubernetes-metrics
-      tolerations:
-      - effect: NoSchedule
-        key: node-role.kubernetes.io/master
       containers:
       - name: splunk-fluentd-k8s-metrics-agg
         image: splunk/k8s-metrics-aggr:1.1.0


### PR DESCRIPTION
A path needs to be specified for where to save the pos file generated by
the fluentd plugin. You can find more information in the upgrade docs:
https://github.com/reevoo/fluent-plugin-systemd/blob/master/docs/upgrading.md

I ran `make manifests` and it generated some unrelated changes in the manifests. Are you trying to keep the manifests in sync with the makefile generated manifests?