### PR TITLE
Missing rbac create condition

### DIFF
--- a/helm-chart/splunk-kubernetes-metrics/templates/clusterRole.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/clusterRole.yaml
@@ -1,4 +1,5 @@
 # This role allows read access to the kubelet summary API
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -17,3 +18,4 @@ rules:
   - "nodes/metrics"
   verbs:
   - "get"
+{{- end -}}

--- a/helm-chart/splunk-kubernetes-metrics/templates/clusterRoleAggregator.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/clusterRoleAggregator.yaml
@@ -1,4 +1,5 @@
 # This role allows read access to the kubelet summary API
+{{- if .Values.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -19,3 +20,4 @@ rules:
   verbs:
   - get
   - list
+{{- end -}}


### PR DESCRIPTION
Missing rbac create condition on clusterRole and clusterRoleAggregator for splunk-kuberntes-metrics chart