### PR TITLE
Allowing possiblity to set cluster name at global level

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/examples/insecure.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/examples/insecure.yaml
@@ -8,7 +8,8 @@ global:
       indexName: main
       # connection to splunk is insecure
       insecureSSL: true
-
+  kubernetes: 
+    clusterName: "cluster_name"
 
 splunk-kubernetes-objects:
   # RBAC is disabled

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -9,7 +9,8 @@
 #   splunk:
 #     # HEC related configurations
 #     hec:
-#
+#   kubernetes:
+#     clusterName: "cluster_name"
 # For other configurations for sub-charts, please check their values.yaml for details.
 
 ## Enabling logging will install the `splunk-kubernetes-logging` chart to a kubernetes

--- a/helm-chart/splunk-kubernetes-logging/templates/_helpers.tpl
+++ b/helm-chart/splunk-kubernetes-logging/templates/_helpers.tpl
@@ -100,8 +100,8 @@ def extract_container_info:
   | .namespace = set_namespace($parts[1])
   | .container_name = ($cparts[:-1] | join("-"))
   | .container_id = ($cparts[-1] | rtrimstr(".log"))
-  {{- if .Values.kubernetes.clusterName }}
-  | .cluster_name = "{{ .Values.kubernetes.clusterName }}"
+  {{- if or .Values.kubernetes.clusterName .Values.global.kubernetes.clusterName }}
+  | .cluster_name = "{{ . }}"
   {{- end }}
   | .;
 

--- a/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
@@ -232,7 +232,7 @@ data:
           namespace
           container_name
           container_id
-          {{- if .Values.kubernetes.clusterName }}
+          {{- if or .Values.kubernetes.clusterName .Values.global.kubernetes.clusterName }}
           cluster_name
           {{- end }}
         </fields>

--- a/helm-chart/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-kubernetes-logging/values.yaml
@@ -18,7 +18,8 @@ global:
       indexRouting:
       # indexRoutingDefaultIndex tells which index to use for the default kubenetes namespace. Used with indexRouting. Default is main.
       indexRoutingDefaultIndex:
-
+  kubernetes:
+    clusterName: "cluster_name"
 
 # logLevel is to set log level of the Splunk log collector. Avaiable values are:
 # * trace
@@ -271,4 +272,4 @@ affinity: {}
 # = Kubernetes Connection Configs =
 kubernetes:
   # The cluster name used to tag logs. Default is cluster_name
-  clusterName: "cluster_name"
+  clusterName: 

--- a/helm-chart/splunk-kubernetes-metrics/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/configMap.yaml
@@ -16,7 +16,7 @@ data:
     <source>
       @type kubernetes_metrics
       tag kube.*
-      node_name "#{ENV['SPLUNK_HEC_HOST']}"
+      node_name "#{ENV['MY_NODE_IP']}"
       {{- with .Values.kubernetes.kubeletPort }}
       kubelet_port {{ . }}
       {{- end }}
@@ -33,7 +33,7 @@ data:
       {{- with .Values.kubernetes.secretDir }}
       secret_dir {{ . }}
       {{- end }}
-      {{- with .Values.kubernetes.clusterName }}
+      {{- with or .Values.kubernetes.clusterName .Values.global.kubernetes.clusterName }}
       cluster_name {{ . }}
       {{- end }}
     </source>
@@ -41,7 +41,7 @@ data:
       @type record_modifier
       <record>
         metric_name ${tag}
-        {{- with .Values.kubernetes.clusterName }}
+        {{- with or .Values.kubernetes.clusterName .Values.global.kubernetes.clusterName }}
         cluster_name {{ . }}
         {{- end }}
       </record>

--- a/helm-chart/splunk-kubernetes-metrics/templates/configMapMetricsAggregator.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/configMapMetricsAggregator.yaml
@@ -24,7 +24,7 @@ data:
       @type record_modifier
       <record>
         metric_name ${tag}
-        {{- with .Values.kubernetes.clusterName }}
+        {{- with or .Values.kubernetes.clusterName .Values.global.kubernetes.clusterName }}
         cluster_name {{ . }}
         {{- end }}
       </record>

--- a/helm-chart/splunk-kubernetes-metrics/templates/deployment.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/deployment.yaml
@@ -48,6 +48,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: MY_NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP 
           - name: SPLUNK_HEC_TOKEN
             valueFrom:
               secretKeyRef:

--- a/helm-chart/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/values.yaml
@@ -14,7 +14,8 @@ global:
       port: 8088
       protocol: https
       insecureSSL: false
-
+  kubernetes:
+    clusterName: "cluster_name"
 
 # = Log Level =
 # logLevel is to set log level of the Splunk kubernetes metrics collector. Avaiable values are:
@@ -154,4 +155,4 @@ kubernetes:
   # Path of the location where pod's service account's credentials are stored. Usually you don't need to care about this config, the default value should work in most cases.
   secretDir:
   # The cluster name used to tag cluster metrics from the aggregator. Default is cluster_name
-  clusterName: "cluster_name"
+  clusterName: 

--- a/helm-chart/splunk-kubernetes-objects/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-objects/templates/configMap.yaml
@@ -84,7 +84,7 @@ data:
 
     <filter kube.**>
       @type jq_transformer
-      jq '.record.cluster_name = "{{ .Values.kubernetes.clusterName }}" | .record'
+      jq '.record.cluster_name = "{{ or .Values.kubernetes.clusterName .Values.global.kubernetes.clusterName }}" | .record'
     </filter>
 
     <match kube.**>
@@ -114,7 +114,7 @@ data:
       ca_file /fluentd/etc/splunk/hec_ca_file
       {{- end }}
       <fields>
-        {{- if .Values.kubernetes.clusterName }}
+        {{- if or .Values.kubernetes.clusterName .Values.global.kubernetes.clusterName }}
         cluster_name
         {{- end }}
       </fields>

--- a/helm-chart/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-kubernetes-objects/values.yaml
@@ -15,7 +15,8 @@ global:
       protocol: https
       port: 8088
       insecureSSL: false
-
+  kubernetes:
+    clusterName: "cluster_name"
 
 # = Log Level =
 # logLevel is to set log level of the object collector. Avaiable values are:
@@ -62,7 +63,7 @@ kubernetes:
   # Path of the location where pod's service account's credentials are stored. Usually you don't need to care about this config, the default value should work in most cases.
   secretDir:
   # The cluster name used to tag cluster metrics from the aggregator. Default is cluster_name
-  clusterName: "cluster_name"
+  clusterName: 
 
 
 # = Object Lists =


### PR DESCRIPTION
1) Metric scrapping fails with node name. Hence exposed node ip as environment variable and using it to scrape metrics
2) Allow setting cluster name at global level