### PR TITLE
Support for private repositories

### DIFF
--- a/helm-chart/splunk-kubernetes-logging/templates/_helpers.tpl
+++ b/helm-chart/splunk-kubernetes-logging/templates/_helpers.tpl
@@ -116,3 +116,10 @@ def extract_container_info:
 
 .record | extract_container_info | .sourcetype = (find_sourcetype(.pod; .container_name) // "kube:container:\(.container_name)")
 {{- end -}}
+
+{{/*
+Create the image name
+*/}}
+{{- define "splunk-kubernetes-logging.image" -}}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.name .Values.image.tag -}}
+{{- end -}}

--- a/helm-chart/splunk-kubernetes-logging/templates/daemonset.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/daemonset.yaml
@@ -31,7 +31,7 @@ spec:
       {{- end }}
       containers:
       - name: splunk-fluentd-k8s-logs
-        image: {{ .Values.image.name }}
+        image: {{ template "splunk-kubernetes-logging.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
           - -c

--- a/helm-chart/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-kubernetes-logging/values.yaml
@@ -245,7 +245,9 @@ logs:
 
 # Defines which version of image to use, and how it should be pulled.
 image:
-  name: splunk/fluentd-hec:1.1.1
+  registry: docker.io
+  name: splunk/fluentd-hec
+  tag: 1.1.0
   pullPolicy: Always
 
 

--- a/helm-chart/splunk-kubernetes-metrics/templates/_helpers.tpl
+++ b/helm-chart/splunk-kubernetes-metrics/templates/_helpers.tpl
@@ -52,3 +52,16 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the image name
+*/}}
+{{- define "splunk-kubernetes-metrics.image" -}}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.name .Values.image.tag -}}
+{{- end -}}
+{{/*
+Create the aggregate image name
+*/}}
+{{- define "splunk-kubernetes-metrics.imageAgg" -}}
+{{- printf "%s/%s:%s" .Values.imageAgg.registry .Values.imageAgg.name .Values.imageAgg.tag -}}
+{{- end -}}

--- a/helm-chart/splunk-kubernetes-metrics/templates/deployment.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       {{- end }}
       containers:
       - name: splunk-fluentd-k8s-metrics
-        image: {{ .Values.image.name }}
+        image: {{ template "splunk-kubernetes-metrics.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
           - name: KUBERNETES_NODE_IP

--- a/helm-chart/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
       - name: splunk-fluentd-k8s-metrics-agg
-        image: {{ .Values.imageAgg.name }}
+        image: {{ template "splunk-kubernetes-metrics.imageAgg" . }}
         imagePullPolicy: {{ .Values.imageAgg.pullPolicy }}
         env:
           - name: SPLUNK_HEC_TOKEN

--- a/helm-chart/splunk-kubernetes-metrics/templates/serviceAccount.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/serviceAccount.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
+{{ if .Values.image.usePullSecret }}
+imagePullSecrets:
+- name: {{ .Values.image.pullSecretName }}
+{{ end }}
 kind: ServiceAccount
 metadata:
   name: {{ template "splunk-kubernetes-metrics.serviceAccountName" . }}

--- a/helm-chart/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/values.yaml
@@ -42,6 +42,7 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+  usePullSecrets: false
 
 
 # = Splunk HEC Connection =
@@ -81,13 +82,21 @@ secret:
 
 
 image:
-  name: splunk/k8s-metrics:1.1.1
+  registry: docker.io
+  name: splunk/k8s-metrics
+  tag: 1.1.0
   pullPolicy: Always
+  usePullSecret: false
+  pullsecretName: 
 
 
 imageAgg:
-  name: splunk/k8s-metrics-aggr:1.1.0
+  registry: docker.io
+  name: splunk/k8s-metrics-aggr
+  tag: 1.1.0
   pullPolicy: Always
+  usePullSecret: false
+  pullsecretName: 
 
 
 resources:

--- a/helm-chart/splunk-kubernetes-objects/templates/_helpers.tpl
+++ b/helm-chart/splunk-kubernetes-objects/templates/_helpers.tpl
@@ -81,3 +81,10 @@ Rules:
 {{- $mem -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the image name
+*/}}
+{{- define "splunk-kubernetes-objects.image" -}}
+{{- printf "%s/%s:%s" .Values.image.registry .Values.image.name .Values.image.tag -}}
+{{- end -}}

--- a/helm-chart/splunk-kubernetes-objects/templates/deployment.yaml
+++ b/helm-chart/splunk-kubernetes-objects/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
       {{- end }}
       containers:
       - name: splunk-fluentd-k8s-objects
-        image: {{ .Values.image.name }}
+        image: {{ template "splunk-kubernetes-objects.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
           - -c

--- a/helm-chart/splunk-kubernetes-objects/templates/serviceAccount.yaml
+++ b/helm-chart/splunk-kubernetes-objects/templates/serviceAccount.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
+{{ if .Values.image.usePullSecret }}
+imagePullSecrets:
+- name: {{ .Values.image.pullSecretName }}
+{{ end }}
 kind: ServiceAccount
 metadata:
   name: {{ template "splunk-kubernetes-objects.serviceAccountName" . }}

--- a/helm-chart/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-kubernetes-objects/values.yaml
@@ -44,6 +44,7 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
+  usePullSecrets: false
 
 
 # = Kubernetes Connection Configs =
@@ -172,8 +173,12 @@ secret:
 
 
 image:
-  name: splunk/kube-objects:1.1.0
+  registry: docker.io
+  name: splunk/kube-objects
+  tag: 1.1.0
   pullPolicy: IfNotPresent
+  usePullSecret: false
+  pullSecretName:
 
 
 # = Resoruce Limitation Configs =


### PR DESCRIPTION
Made it simpler to handle private repositories by adding the following properties to each subchart's image:

| Property        | Default           | Descripton  |
|:------------- |:-------------:|:-----|
| registry      | docker.io | The domain of the registry to pull the image from |
| name      |       | The name of the image to pull |
| tag | 1.1.0      |    The tag of the image to pull |
| usePullSecret | false | Indicates if the image should be pulled using authentication from a secret |
| pullSecretName | | The name of the pull secret to attach to the respective serviceaccount used to pull the image

Example of custom property usage:
```
splunk-kubernetes-logging:
  image: 
    registry: artifactory.foo.com
    name: splunk/fluentd-hec
    tag: 1.1.0

splunk-kubernetes-objects:
  image:
    registry: artifactory.foo.com
    name: splunk/kube-objects
    tag: 1.1.0
    usePullSecret: true
    pullSecretName: artifactory-registry

splunk-kubernetes-metrics:
  image:
    registry: artifactory.foo.com
    name: splunk/k8s-metrics
    tag: 1.1.0
    usePullSecret: true
    pullSecretName: artifactory-registry
  imageAgg:
    registry: artifactory.foo.com
    name: splunk/k8s-metrics-aggr
    tag: 1.1.0
    usePullSecret: true
    pullSecretName: artifactory-registry
