### PR TITLE
Add missing configurations to metrics & metrics aggregator

### DIFF
--- a/helm-chart/splunk-kubernetes-metrics/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/configMap.yaml
@@ -36,6 +36,9 @@ data:
       {{- with .Values.kubernetes.clusterName }}
       cluster_name {{ . }}
       {{- end }}
+      {{- with .Values.metricsInterval }}
+      interval {{ . }}
+      {{- end }}
     </source>
     <filter kube.**>
       @type record_modifier
@@ -97,7 +100,7 @@ data:
       {{- end }}
       {{- if or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile }}
       ca_file /fluentd/etc/splunk/hec_ca_file
-      {{- end }} 
+      {{- end }}
       {{- with .Values.buffer }}
       <buffer>
       {{- range $parameter, $value := . }}

--- a/helm-chart/splunk-kubernetes-metrics/templates/configMapMetricsAggregator.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/configMapMetricsAggregator.yaml
@@ -19,6 +19,12 @@ data:
       {{- with .Values.kubernetes.kubeletPort }}
       kubelet_port {{ . }}
       {{- end }}
+      {{- with .Values.kubernetes.clusterName }}
+      cluster_name {{ . }}
+      {{- end }}
+      {{- with .Values.metricsInterval }}
+      interval {{ . }}
+      {{- end }}
     </source>
     <filter kube.**>
       @type record_modifier


### PR DESCRIPTION
* Add cluster_name and interval to metrics aggregator
* Add interval to metrics

Looks like this two configurations (cluster_name and interval) at source level were missing. First one cause metrics to send a `name` field with `cluster_name` (default) value, and the other to specify the interval in which data will be taken.

Also, I think it will also close #122 