### PR TITLE
added aggregatorTolerations variable

### DIFF
--- a/helm-chart/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
@@ -31,7 +31,7 @@ spec:
       affinity:
 {{ toYaml . | indent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.aggregatorTolerations }}
       tolerations:
 {{ toYaml . | indent 8 }}
       {{- end }}

--- a/helm-chart/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/values.yaml
@@ -136,6 +136,9 @@ tolerations:
   - key: node-role.kubernetes.io/master
     effect: NoSchedule
 
+# Tolerations for the aggregator pod. We do not really want this running on the master nodes, so we leave this 
+# blank by default.
+aggregatorTolerations: {}
 
 affinity: {}
 


### PR DESCRIPTION
added aggregatorTolerations variable to allow metrics aggregation tolerations to be set independently to the metrics pods.

For example, you may want the metrics collector daemonset to run on the master, however you probably don't want the aggregator to end up on a master node.