### PR TITLE
ADDON-21681: Splunk Connect for Kubernetes tries to connect to the Kubernetes node name	

### DIFF
--- a/helm-chart/splunk-kubernetes-logging/templates/daemonset.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/daemonset.yaml
@@ -37,7 +37,7 @@ spec:
           - -c
           - /fluentd/etc/fluent.conf
         env:
-          - name: SPLUNK_HEC_HOST
+          - name: NODE_NAME
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName

--- a/helm-chart/splunk-kubernetes-metrics/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/configMap.yaml
@@ -16,7 +16,7 @@ data:
     <source>
       @type kubernetes_metrics
       tag kube.*
-      node_name "#{ENV['SPLUNK_HEC_HOST']}"
+      node_name "#{ENV['NODE_NAME']}"
       {{- with .Values.kubernetes.kubeletPort }}
       kubelet_port {{ . }}
       {{- end }}

--- a/helm-chart/splunk-kubernetes-metrics/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/configMap.yaml
@@ -16,7 +16,7 @@ data:
     <source>
       @type kubernetes_metrics
       tag kube.*
-      node_name "#{ENV['NODE_NAME']}"
+      node_name {{ .Values.kubernetes.nodeName | default "\"#{ENV['NODE_NAME']}\"" }}
       {{- with .Values.kubernetes.kubeletPort }}
       kubelet_port {{ . }}
       {{- end }}

--- a/helm-chart/splunk-kubernetes-metrics/templates/deployment.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/deployment.yaml
@@ -44,6 +44,10 @@ spec:
         image: {{ .Values.image.name }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
+          - name: KUBERNETES_NODE_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.hostIP
           - name: SPLUNK_HEC_HOST
             valueFrom:
               fieldRef:

--- a/helm-chart/splunk-kubernetes-metrics/templates/deployment.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
-          - name: SPLUNK_HEC_HOST
+          - name: NODE_NAME
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName

--- a/helm-chart/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/values.yaml
@@ -155,3 +155,5 @@ kubernetes:
   secretDir:
   # The cluster name used to tag cluster metrics from the aggregator. Default is cluster_name
   clusterName: "cluster_name"
+  # (Misnomer) The address used to access the kubelet. Must be either a domain name or an IP address
+  nodeName:

--- a/helm-chart/splunk-kubernetes-objects/templates/deployment.yaml
+++ b/helm-chart/splunk-kubernetes-objects/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-          - name: SPLUNK_HEC_HOST
+          - name: NODE_NAME
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName

--- a/manifests/splunk-kubernetes-logging/daemonset.yaml
+++ b/manifests/splunk-kubernetes-logging/daemonset.yaml
@@ -26,7 +26,7 @@ spec:
         - "-c"
         - "/fluentd/etc/fluent.conf"
         env:
-        - name: SPLUNK_HEC_HOST
+        - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName

--- a/manifests/splunk-kubernetes-metrics/configMap.yaml
+++ b/manifests/splunk-kubernetes-metrics/configMap.yaml
@@ -15,7 +15,7 @@ data:
     <source>
       @type kubernetes_metrics
       tag kube.*
-      node_name "#{ENV['SPLUNK_HEC_HOST']}"
+      node_name "#{ENV['NODE_NAME']}"
       use_rest_client_ssl true
       cluster_name cluster_name
     </source>

--- a/manifests/splunk-kubernetes-metrics/deployment.yaml
+++ b/manifests/splunk-kubernetes-metrics/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        - name: SPLUNK_HEC_HOST
+        - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName

--- a/manifests/splunk-kubernetes-metrics/deployment.yaml
+++ b/manifests/splunk-kubernetes-metrics/deployment.yaml
@@ -32,6 +32,10 @@ spec:
         image: splunk/k8s-metrics:1.1.0
         imagePullPolicy: Always
         env:
+        - name: KUBERNETES_NODE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: SPLUNK_HEC_HOST
           valueFrom:
             fieldRef:

--- a/manifests/splunk-kubernetes-objects/deployment.yaml
+++ b/manifests/splunk-kubernetes-objects/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        - name: SPLUNK_HEC_HOST
+        - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName


### PR DESCRIPTION
- I renamed some instances of SPLUNK_HEC_HOST to NODE_NAME since there's actually two separate variables called SPLUNK_HEC_HOST. One of these doesn't make sense as SPLUNK_HEC_HOST. This isn't the main point of this PR.
- KUBERNETES_NODE_IP is a variable that holds the IP of the node on the Kubernetes network. This can be used in lieu of the Kubernetes node name in cases where the node name is unresolvable.
- The nodeName variable allows configuration of which Kubernetes node name to use. The default case is still NODE_NAME (the variable formerly known as SPLUNK_HEC_HOST) which is the name of the Kubernetes node. This can be set to a specific value, but this PR also allows you to set it to KUBERNETES_NODE_IP which is more reliable.
