### PR TITLE
Added support for path and exclude_path to be populated in fluentd configMap. Resolves issue #152

### DIFF
--- a/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
@@ -44,7 +44,10 @@ data:
       @type tail
       @label @SPLUNK
       tag tail.containers.*
-      path /var/log/containers/*.log
+      path {{ .Values.global.fluentd.path | default "/var/log/containers/*.log" }}
+      {{- if .Values.global.fluentd.exclude_path }}
+      exclude_path {{ .Values.global.fluentd.exclude_path | toJson }}
+      {{- end }}
       pos_file /var/log/splunk-fluentd-containers.log.pos
       path_key source
       read_from_head true

--- a/helm-chart/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-kubernetes-logging/values.yaml
@@ -20,6 +20,17 @@ global:
       indexRoutingDefaultIndex:
   kubernetes:
     clusterName: "cluster_name"
+  
+  # Override global Fluentd config path and exclude path.
+  # This is can be used to exclude verbose logs including various system and Helm/Tiller related logs.
+  fluentd:
+    # path of logfiles, default /var/log/containers/*.log
+    path: /var/log/containers/*.log
+    # paths of logfiles to exclude. object type is array as per fluentd specification:
+    # https://docs.fluentd.org/input/tail#exclude_path
+    exclude_path: 
+    #  - /var/log/containers/kube-svc-redirect*.log
+    #  - /var/log/containers/tiller*.log
 
 
 # logLevel is to set log level of the Splunk log collector. Avaiable values are:


### PR DESCRIPTION
## Proposed changes

Added the possibility to change `path` and `exclude_path` to the fluentd configuration.
This will make it possible exclude noisy logs like networking services, tiller and even the fluentd log it self.

This is a solution on to my feature request issue:
https://github.com/splunk/splunk-connect-for-kubernetes/issues/152

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

