### PR TITLE
Add linux node selector to deployments

### DIFF
--- a/manifests/splunk-kubernetes-logging/daemonset.yaml
+++ b/manifests/splunk-kubernetes-logging/daemonset.yaml
@@ -18,6 +18,8 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
       - name: splunk-fluentd-k8s-logs
         image: splunk/fluentd-hec:1.1.1

--- a/manifests/splunk-kubernetes-metrics/deployment.yaml
+++ b/manifests/splunk-kubernetes-metrics/deployment.yaml
@@ -27,6 +27,8 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
       - name: splunk-fluentd-k8s-metrics
         image: splunk/k8s-metrics:1.1.1

--- a/manifests/splunk-kubernetes-metrics/deploymentMetricsAggregator.yaml
+++ b/manifests/splunk-kubernetes-metrics/deploymentMetricsAggregator.yaml
@@ -21,6 +21,8 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       serviceAccountName: splunk-kubernetes-metrics
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
       - name: splunk-fluentd-k8s-metrics-agg
         image: splunk/k8s-metrics-aggr:1.1.0

--- a/manifests/splunk-kubernetes-objects/deployment.yaml
+++ b/manifests/splunk-kubernetes-objects/deployment.yaml
@@ -22,6 +22,8 @@ spec:
       annotations: {}
     spec:
       serviceAccountName: splunk-kubernetes-objects
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       terminationGracePeriodSeconds: 30
       containers:
       - name: splunk-fluentd-k8s-objects


### PR DESCRIPTION
## Proposed changes

Add linux node selectors to deployments and daemonsets.  Prevents the pods from scheduling on windows nodes in a hybrid cluster.  

This is a necessary first step for https://github.com/splunk/splunk-connect-for-kubernetes/issues/163


## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

