### PR TITLE
Ensure clusterName can be used from global.kubernetes.clusterName

### DIFF
--- a/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
@@ -211,7 +211,7 @@ data:
         hec_port {{ . }}
         {{- end }}
         hec_token "#{ENV['SPLUNK_HEC_TOKEN']}"
-        host "#{ENV['SPLUNK_HEC_HOST']}"
+        host "#{ENV['NODE_NAME']}"
         source_key source
         sourcetype_key sourcetype
         {{- if or .Values.splunk.hec.indexRouting .Values.global.splunk.hec.indexRouting }}

--- a/helm-chart/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-kubernetes-logging/values.yaml
@@ -299,4 +299,4 @@ priorityClassName:
 # = Kubernetes Connection Configs =
 kubernetes:
   # The cluster name used to tag logs. Default is cluster_name
-  clusterName: "cluster_name"
+  clusterName:

--- a/helm-chart/splunk-kubernetes-metrics/templates/configMapMetricsAggregator.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/configMapMetricsAggregator.yaml
@@ -84,7 +84,7 @@ data:
       hec_port {{ . }}
       {{- end }}
       hec_token "#{ENV['SPLUNK_HEC_TOKEN']}"
-      host "#{ENV['MY_NODE_NAME']}"
+      host "#{ENV['NODE_NAME']}"
       {{- with or .Values.splunk.hec.indexName .Values.global.splunk.hec.indexName }}
       index {{ . }}
       {{- end }}

--- a/helm-chart/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/values.yaml
@@ -173,4 +173,4 @@ kubernetes:
   # Path of the location where pod's service account's credentials are stored. Usually you don't need to care about this config, the default value should work in most cases.
   secretDir:
   # The cluster name used to tag cluster metrics from the aggregator. Default is cluster_name
-  clusterName: "cluster_name"
+  clusterName:

--- a/helm-chart/splunk-kubernetes-objects/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-objects/templates/configMap.yaml
@@ -97,7 +97,7 @@ data:
       hec_port {{ . }}
       {{- end }}
       hec_token "#{ENV['SPLUNK_HEC_TOKEN']}"
-      host "#{ENV['SPLUNK_HEC_HOST']}"
+      host "#{ENV['NODE_NAME']}"
       source_key source
       sourcetype_key sourcetype
       {{- with or .Values.splunk.hec.indexName .Values.global.splunk.hec.indexName }}

--- a/helm-chart/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-kubernetes-objects/values.yaml
@@ -63,7 +63,7 @@ kubernetes:
   # Path of the location where pod's service account's credentials are stored. Usually you don't need to care about this config, the default value should work in most cases.
   secretDir:
   # The cluster name used to tag cluster metrics from the aggregator. Default is cluster_name
-  clusterName: "cluster_name"
+  clusterName:
 
 
 # = Object Lists =


### PR DESCRIPTION
## Proposed changes

Fixes https://github.com/splunk/splunk-connect-for-kubernetes/issues/184

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

