### PR TITLE
Fix host field with kubernetes node name

### DIFF
--- a/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
@@ -211,7 +211,7 @@ data:
         hec_port {{ . }}
         {{- end }}
         hec_token "#{ENV['SPLUNK_HEC_TOKEN']}"
-        host "#{ENV['SPLUNK_HEC_HOST']}"
+        host "#{ENV['NODE_NAME']}"
         source_key source
         sourcetype_key sourcetype
         {{- if or .Values.splunk.hec.indexRouting .Values.global.splunk.hec.indexRouting }}

--- a/helm-chart/splunk-kubernetes-objects/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-objects/templates/configMap.yaml
@@ -97,7 +97,7 @@ data:
       hec_port {{ . }}
       {{- end }}
       hec_token "#{ENV['SPLUNK_HEC_TOKEN']}"
-      host "#{ENV['SPLUNK_HEC_HOST']}"
+      host "#{ENV['NODE_NAME']}"
       source_key source
       sourcetype_key sourcetype
       {{- with or .Values.splunk.hec.indexName .Values.global.splunk.hec.indexName }}


### PR DESCRIPTION
## Proposed changes

'host' fields in splunk logs are all empty. This pr to fix that by using the Kubernetes node name for the host field.
https://github.com/splunk/splunk-connect-for-kubernetes/issues/192

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

