### PR TITLE
Ensure clusterName can be used from global.kubernetes.clusterName

### DIFF
--- a/helm-chart/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-kubernetes-logging/values.yaml
@@ -313,6 +313,6 @@ priorityClassName:
 # = Kubernetes Connection Configs =
 kubernetes:
   # The cluster name used to tag logs. Default is cluster_name
-  clusterName: "cluster_name"
+  clusterName:
   # Add privileged access to containers for openshift compatability
   openshift: false

--- a/helm-chart/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/values.yaml
@@ -173,6 +173,6 @@ kubernetes:
   # Path of the location where pod's service account's credentials are stored. Usually you don't need to care about this config, the default value should work in most cases.
   secretDir:
   # The cluster name used to tag cluster metrics from the aggregator. Default is cluster_name
-  clusterName: "cluster_name"
+  clusterName:
   # Add privileged access to containers for openshift compatability
   openshift: false

--- a/helm-chart/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-kubernetes-objects/values.yaml
@@ -63,7 +63,7 @@ kubernetes:
   # Path of the location where pod's service account's credentials are stored. Usually you don't need to care about this config, the default value should work in most cases.
   secretDir:
   # The cluster name used to tag cluster metrics from the aggregator. Default is cluster_name
-  clusterName: "cluster_name"
+  clusterName:
   # Add privileged access to containers for openshift compatability
   openshift: false
 


### PR DESCRIPTION
## Proposed changes

Fixes #184

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
