### PR TITLE
removed unnecessary .toYAML from priorityClassName to allow it to be …

### DIFF
--- a/helm-chart/splunk-kubernetes-logging/templates/daemonset.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/daemonset.yaml
@@ -99,5 +99,5 @@ spec:
         secret:
           secretName: {{ template "splunk-kubernetes-logging.secret" . }}
       {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }} {{ toYaml . | indent 8 }}
+      priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}

--- a/helm-chart/splunk-kubernetes-metrics/templates/deployment.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/deployment.yaml
@@ -79,5 +79,5 @@ spec:
         secret:
           secretName: {{ template "splunk-kubernetes-metrics.secret" . }}
       {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }} {{ toYaml . | indent 8 }}
+      priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}


### PR DESCRIPTION
…used as before

## Proposed changes

Removing .toYaml block from priorityClassName as it is unnecessary and breaks the existing way of configuring it. As discussed with @chaitanyaphalak on Slack.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x ] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [ x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

