### PR TITLE
Fixed problem in splunk-kubernetes-logging configMap. #208

### DIFF
--- a/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
@@ -209,7 +209,7 @@ data:
       # = filters for monitor agent =
       <filter monitor_agent>
         @type jq_transformer
-        jq ".record.source = \"namespace:#{ENV['MY_NAMESPACE']}/pod:#{ENV['MY_POD_NAME']}\" | .record.sourcetype = \"fluentd:monitor-agent\" | .record.cluster_name = "{{ or .Values.kubernetes.clusterName .Values.global.kubernetes.clusterName | default "cluster_name" }}" | .record"
+        jq '.record.source = "namespace:#{ENV[\'MY_NAMESPACE\']}/pod:#{ENV[\'MY_POD_NAME\']}" | .record.sourcetype = "fluentd:monitor-agent" | .record.cluster_name = "{{ or .Values.kubernetes.clusterName .Values.global.kubernetes.clusterName | default "cluster_name" }}" | .record'
       </filter>
 
       # = output =


### PR DESCRIPTION

## Proposed changes

Fixed problem with quotes not being correct on line 212 of configMap for splunk-kubernetes-logging. 
A bug was submitted previously, and can be found here: #208 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x ] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x ] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

