### PR TITLE
remove version label from selector in manifests

### DIFF
--- a/helm-chart/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-kubernetes-logging/values.yaml
@@ -319,7 +319,8 @@ tolerations:
 
 
 # Defines which nodes should be selected to deploy the fluentd daemonset.
-nodeSelector: {}
+nodeSelector:
+  beta.kubernetes.io/os: linux
 
 
 # Defines node affinity to restrict pod deployment.

--- a/helm-chart/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/values.yaml
@@ -162,8 +162,8 @@ metricsInterval: 15s
 
 
 # Defines which nodes should be selected to deploy the fluentd daemonset.
-nodeSelector: {}
-  # kubernetes.io/role: master
+nodeSelector:
+  beta.kubernetes.io/os: linux
 
 
 # This default tolerations allow the daemonset to be deployed on master nodes,

--- a/helm-chart/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-kubernetes-objects/values.yaml
@@ -239,7 +239,8 @@ buffer:
 
 
 # Defines which nodes should be selected to deploy the fluentd daemonset.
-nodeSelector: {}
+nodeSelector:
+  beta.kubernetes.io/os: linux
 
 
 # This default tolerations allow the daemonset to be deployed on master nodes,

--- a/manifests/splunk-kubernetes-logging/daemonset.yaml
+++ b/manifests/splunk-kubernetes-logging/daemonset.yaml
@@ -11,7 +11,6 @@ spec:
   selector:
     matchLabels:
       app: splunk-kubernetes-logging
-      version: 1.2.0
   template:
     metadata:
       labels:

--- a/manifests/splunk-kubernetes-metrics/deployment.yaml
+++ b/manifests/splunk-kubernetes-metrics/deployment.yaml
@@ -11,7 +11,6 @@ spec:
   selector:
     matchLabels:
       name: splunk-kubernetes-metrics
-      version: 1.2.0
   template:
     metadata:
       name: splunk-kubernetes-metrics

--- a/manifests/splunk-kubernetes-objects/deployment.yaml
+++ b/manifests/splunk-kubernetes-objects/deployment.yaml
@@ -11,7 +11,6 @@ spec:
     matchLabels:
       app: splunk-kubernetes-objects
       engine: fluentd
-      version: 1.2.0
   replicas: 1
   template:
     metadata:

--- a/tools/gen_manifest.rb
+++ b/tools/gen_manifest.rb
@@ -21,7 +21,6 @@ def sanitize_yaml(yaml)
 
   yaml['metadata']['labels']['version'] = @version
   yaml.fetch('spec', {}).tap { |spec|
-    spec.fetch('selector', {}).fetch('matchLabels', {})['version'] = @version
     spec.fetch('template', {}).fetch('metadata', {}).fetch('labels', {})['version'] = @version
   }
 


### PR DESCRIPTION
## Proposed changes

Selector labels are immutable after creation in apps/v1 as seen in the kubernetes [deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#label-selector-updates
) and [daemonset](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#pod-selector) documentation. Using a version label in the selector blocks upgrades from proceeding via kubectl apply and requires deleting the resources before upgrading.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

