### PR TITLE
Missing end clause

### DIFF
--- a/helm-chart/splunk-kubernetes-objects/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-objects/templates/configMap.yaml
@@ -118,6 +118,7 @@ data:
       {{- with or .Values.splunk.hec.indexName .Values.global.splunk.hec.indexName }}
       index {{ . }}
       {{- end }}
+      {{- end }}
       insecure_ssl {{ or .Values.splunk.hec.insecureSSL .Values.global.splunk.hec.insecureSSL }}
       {{- if or .Values.splunk.hec.clientCert .Values.global.splunk.hec.clientCert }}
       client_cert /fluentd/etc/splunk/hec_client_cert


### PR DESCRIPTION

## Proposed changes

The PR #235 introduced a new if/else statement, but forgot to include an end clause.   

This resulted in a parsing error when trying to use the helm chart without index routing.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

