### PR TITLE
add PodSecurityPolicy support and introduce generic securityContext param

### DIFF
--- a/helm-chart/splunk-kubernetes-logging/templates/clusterRole.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/clusterRole.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.podSecurityPolicy.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "splunk-kubernetes-logging.fullname" . }}
+  labels:
+    app: {{ template "splunk-kubernetes-logging.name" . }}
+    chart: {{ template "splunk-kubernetes-logging.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:      ['extensions']
+    resources:      ['podsecuritypolicies']
+    verbs:          ['use']
+    resourceNames:  [{{ template "splunk-kubernetes-logging.fullname" . }}]
+{{- end -}}

--- a/helm-chart/splunk-kubernetes-logging/templates/clusterRoleBinding.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/clusterRoleBinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podSecurityPolicy.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "splunk-kubernetes-logging.fullname" . }}
+  labels:
+    app: {{ template "splunk-kubernetes-logging.name" . }}
+    chart: {{ template "splunk-kubernetes-logging.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "splunk-kubernetes-logging.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "splunk-kubernetes-logging.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/helm-chart/splunk-kubernetes-logging/templates/daemonset.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
       - name: splunk-fluentd-k8s-logs
         image: {{ template "splunk-kubernetes-logging.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- if or .Values.global.kubernetes.openshift .Values.kubernetes.openshift }}
+        {{- if or .Values.global.kubernetes.openshift .Values.kubernetes.openshift .Values.global.kubernetes.securityContext .Values.kubernetes.securityContext }}
         securityContext:
           privileged: true
           runAsUser: 0

--- a/helm-chart/splunk-kubernetes-logging/templates/psp.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/psp.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.podSecurityPolicy.create -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "splunk-kubernetes-logging.fullname" . }}
+  labels:
+    app: {{ template "splunk-kubernetes-logging.name" . }}
+    chart: {{ template "splunk-kubernetes-logging.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+{{- end -}}

--- a/helm-chart/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-kubernetes-logging/values.yaml
@@ -336,6 +336,14 @@ kubernetes:
   clusterName:
   # Add privileged access to containers for openshift compatability
   openshift: false
+  # Add privileged access to containers for any PodSecurityPolicy enabled clusters (same as above for Openshift but generic)
+  securityContext: false
+
+
+# Creates PodSecurityPolicy resources for any pods and associate it with any created service acccounts
+podSecurityPolicy:
+  create: false
+
 
 # List of key/value pairs for metadata purpse.
 # Can be used to define things such as cloud_account_id, cloud_account_region, etc.

--- a/helm-chart/splunk-kubernetes-metrics/templates/clusterRole.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/clusterRole.yaml
@@ -18,4 +18,10 @@ rules:
   - "nodes/metrics"
   verbs:
   - "get"
+  {{- if .Values.podSecurityPolicy.create -}}
+  - apiGroups:      ['extensions']
+    resources:      ['podsecuritypolicies']
+    verbs:          ['use']
+    resourceNames:  [{{ template "splunk-kubernetes-metrics.fullname" . }}]
+  {{- end -}}
 {{- end -}}

--- a/helm-chart/splunk-kubernetes-metrics/templates/deployment.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
       - name: splunk-fluentd-k8s-metrics
         image: {{ template "splunk-kubernetes-metrics.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- if or .Values.global.kubernetes.openshift .Values.kubernetes.openshift }}
+        {{- if or .Values.global.kubernetes.openshift .Values.kubernetes.openshift .Values.global.kubernetes.securityContext .Values.kubernetes.securityContext }}
         securityContext:
           privileged: true
           runAsUser: 0

--- a/helm-chart/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
@@ -39,7 +39,7 @@ spec:
       - name: splunk-fluentd-k8s-metrics-agg
         image: {{ template "splunk-kubernetes-metrics.imageAgg" . }}
         imagePullPolicy: {{ .Values.imageAgg.pullPolicy }}
-        {{- if or .Values.global.kubernetes.openshift .Values.kubernetes.openshift }}
+        {{- if or .Values.global.kubernetes.openshift .Values.kubernetes.openshift .Values.global.kubernetes.securityContext .Values.kubernetes.securityContext }}
         securityContext:
           privileged: true
           runAsUser: 0

--- a/helm-chart/splunk-kubernetes-metrics/templates/psp.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/templates/psp.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.rbac.create .Values.podSecurityPolicy.create -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "splunk-kubernetes-metrics.fullname" . }}
+  labels:
+    app: {{ template "splunk-kubernetes-metrics.name" . }}
+    chart: {{ template "splunk-kubernetes-metrics.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+{{- end -}}

--- a/helm-chart/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-kubernetes-metrics/values.yaml
@@ -206,6 +206,12 @@ kubernetes:
   clusterName:
   # Add privileged access to containers for openshift compatability
   openshift: false
+  # Add privileged access to containers for any PodSecurityPolicy enabled clusters (same as above for Openshift but generic)
+  securityContext: false
+
+# Creates PodSecurityPolicy resources for any pods and associate it with any created service acccounts
+podSecurityPolicy:
+  create: false
 
   # `customFilters` defines the custom filters to be used.
   # This section can be used to define custom filters using plugins like https://github.com/splunk/fluent-plugin-jq

--- a/helm-chart/splunk-kubernetes-objects/templates/clusterRole.yaml
+++ b/helm-chart/splunk-kubernetes-objects/templates/clusterRole.yaml
@@ -9,6 +9,12 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
+  {{- if  .Values.podSecurityPolicy.create }}
+  - apiGroups:      ['extensions']
+    resources:      ['podsecuritypolicies']
+    verbs:          ['use']
+    resourceNames:  [{{ template "splunk-kubernetes-objects.fullname" . }}]
+  {{- end }}
   {{/* create a map for generating the rules */}}
   {{- $groupedObjects := dict }}
   {{- range $apiGroup, $apiVersions := .Values.objects }}

--- a/helm-chart/splunk-kubernetes-objects/templates/deployment.yaml
+++ b/helm-chart/splunk-kubernetes-objects/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       - name: splunk-fluentd-k8s-objects
         image: {{ template "splunk-kubernetes-objects.image" . }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- if or .Values.global.kubernetes.openshift .Values.kubernetes.openshift }}
+        {{- if or .Values.global.kubernetes.openshift .Values.kubernetes.openshift .Values.global.kubernetes.securityContext .Values.kubernetes.securityContext }}
         securityContext:
           privileged: true
           runAsUser: 0

--- a/helm-chart/splunk-kubernetes-objects/templates/psp.yaml
+++ b/helm-chart/splunk-kubernetes-objects/templates/psp.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.podSecurityPolicy.create -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "splunk-kubernetes-objects.fullname" . }}
+  labels:
+    app: {{ template "splunk-kubernetes-objects.name" . }}
+    chart: {{ template "splunk-kubernetes-objects.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  allowedCapabilities:
+  - '*'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - '*'
+{{- end -}}

--- a/helm-chart/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-kubernetes-objects/values.yaml
@@ -46,6 +46,9 @@ rbac:
   # b) you want to create RBAC resources by yourself.
   create: true
 
+# Creates PodSecurityPolicy resources for any pods and associate it with any created service acccounts
+podSecurityPolicy:
+  create: false
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
@@ -78,7 +81,8 @@ kubernetes:
   clusterName:
   # Add privileged access to containers for openshift compatability
   openshift: false
-
+  # Add privileged access to containers for any PodSecurityPolicy enabled clusters (same as above for Openshift but generic)
+  securityContext: false
 
 # = Object Lists =
 # NOTE: at least one object must be provided.


### PR DESCRIPTION
## Proposed changes

Kubernetes clusters (e.g. AKS, EKS, or VMware PKS in my case) that have `PodSecurityPolicy` enabled would benefit from OOTB `PodSecurityPolicy` support in Splunk Connect for Kubernetes.  
 
This also will benefit from changing the `openshift` parameter to the more generic `securityContext` as this setting has nothing to do with OpenShift per se, and is more of something required for any locked down Kubernetes cluster with `PodSecurityPolicy` enabled.

This patch introduces 
- optional (default disabled) `PodSecurityPolicy` objects (wide open privileged for now - probably could be eventually tailored to be more restrictive) for the helm charts, 
- a new `securityContext` parameter that acts like the `openshift` parameter, but doesn't eliminate the latter for backwards compatibility

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

