### PR TITLE
For multiline events, use the timestamp of the first event and do not add extra newlines

### DIFF
--- a/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
@@ -158,6 +158,8 @@ data:
         stream_identity_key stream
         multiline_start_regexp {{ $logDef.multiline.firstline }}
         flush_interval {{ $logDef.multiline.flushInterval | default "5s" }}
+        separator ""
+        use_first_timestamp true
       </filter>
       {{- end }}
       {{- end }}


### PR DESCRIPTION
For multiline events, the events can be buffered and the last time stamp is used which can be several seconds off.  Setting **use_first_timestamp true** fixes this problem.

In Splunk my multiline events had extra newlines.  This was fixed by adding **separator ""**  This is because fluentd concat separator default is \n.