### PR TITLE
Enable FluentD Prometheus Endpoint

### DIFF
--- a/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
@@ -34,10 +34,6 @@ data:
     </source>
 
     <source>
-      @type monitor_agent
-    </source>
-
-    <source>
       @type forward
     </source>
 

--- a/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/configMap.yaml
@@ -15,6 +15,9 @@ data:
     @include source.journald.conf
     @include monit.conf
     @include output.conf
+    {{- if .Values.global.prometheus_enabled }}
+    @include prometheus.conf
+    {{- end }}
 
   system.conf: |-
     # system wide configurations
@@ -22,6 +25,38 @@ data:
       log_level {{ or .Values.logLevel .Values.global.logLevel }}
       root_dir /tmp/fluentd
     </system>
+
+  {{- if .Values.global.prometheus_enabled }}
+  prometheus.conf: |-
+    # input plugin that exports metrics
+    <source>
+      @type prometheus
+    </source>
+
+    <source>
+      @type monitor_agent
+    </source>
+
+    <source>
+      @type forward
+    </source>
+
+    # input plugin that collects metrics from MonitorAgent
+    <source>
+      @type prometheus_monitor
+      <labels>
+        host ${hostname}
+      </labels>
+    </source>
+
+    # input plugin that collects metrics for output plugin
+    <source>
+      @type prometheus_output_monitor
+      <labels>
+        host ${hostname}
+      </labels>
+    </source>
+  {{- end }}
 
   source.containers.conf: |-
     # This configuration file for Fluentd / td-agent is used

--- a/helm-chart/splunk-kubernetes-logging/templates/daemonset.yaml
+++ b/helm-chart/splunk-kubernetes-logging/templates/daemonset.yaml
@@ -20,6 +20,10 @@ spec:
         release: {{ .Release.Name }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
+        {{- if .Values.global.prometheus_enabled }}
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '24231'
+        {{- end }}
     spec:
       serviceAccountName: {{ template "splunk-kubernetes-logging.serviceAccountName" . }}
       {{- with .Values.nodeSelector }}

--- a/helm-chart/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-kubernetes-logging/values.yaml
@@ -20,6 +20,7 @@ global:
       indexRoutingDefaultIndex:
   kubernetes:
     clusterName: "cluster_name"
+  prometheus_enabled: true
 
 
   # Override global Fluentd config path and exclude path.

--- a/manifests/splunk-kubernetes-logging/configMap.yaml
+++ b/manifests/splunk-kubernetes-logging/configMap.yaml
@@ -14,12 +14,42 @@ data:
     @include source.journald.conf
     @include monit.conf
     @include output.conf
+    @include prometheus.conf
   system.conf: |-
     # system wide configurations
     <system>
       log_level info
       root_dir /tmp/fluentd
     </system>
+  prometheus.conf: |-
+    # input plugin that exports metrics
+    <source>
+      @type prometheus
+    </source>
+
+    <source>
+      @type monitor_agent
+    </source>
+
+    <source>
+      @type forward
+    </source>
+
+    # input plugin that collects metrics from MonitorAgent
+    <source>
+      @type prometheus_monitor
+      <labels>
+        host ${hostname}
+      </labels>
+    </source>
+
+    # input plugin that collects metrics for output plugin
+    <source>
+      @type prometheus_output_monitor
+      <labels>
+        host ${hostname}
+      </labels>
+    </source>
   source.containers.conf: |-
     # This configuration file for Fluentd / td-agent is used
     # to watch changes to Docker log files. The kubelet creates symlinks that

--- a/manifests/splunk-kubernetes-logging/configMap.yaml
+++ b/manifests/splunk-kubernetes-logging/configMap.yaml
@@ -28,10 +28,6 @@ data:
     </source>
 
     <source>
-      @type monitor_agent
-    </source>
-
-    <source>
       @type forward
     </source>
 

--- a/manifests/splunk-kubernetes-logging/daemonset.yaml
+++ b/manifests/splunk-kubernetes-logging/daemonset.yaml
@@ -16,7 +16,9 @@ spec:
       labels:
         app: splunk-kubernetes-logging
         version: 1.2.0
-      annotations: {}
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '24231'
     spec:
       tolerations:
       - effect: NoSchedule


### PR DESCRIPTION
This commit enables the [fluentd prometheus
plugin](https://github.com/fluent/fluent-plugin-prometheus) to expose
metrics on port 24231.

## Proposed changes

I'm proposing enabling the Prometheus fluentd plugin as it exposes some pretty important metrics (errors sending events using the splunk-hec plugin, etc). Being able to track these things is critical to using this in production.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

