### PR TITLE
implementing ServiceMonitor for usage by the prometheus operator

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/service-headless.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/service-headless.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.global.serviceMonitor.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "splunk-kubernetes-logging.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "splunk-kubernetes-logging.name" . }}
+    chart: {{ template "splunk-kubernetes-logging.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  clusterIP: None
+  ports:
+    - port: {{ .Values.global.serviceMonitor.metricsPort }}
+      protocol: TCP
+      name: http-metrics
+  selector:
+    app: {{ template "splunk-kubernetes-logging.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/serviceMonitor.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/serviceMonitor.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.global.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "splunk-kubernetes-logging.fullname" . }}-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "splunk-kubernetes-logging.name" . }}
+    chart: {{ template "splunk-kubernetes-logging.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.global.serviceMonitor.additionalLabels }}
+{{ toYaml .Values.global.serviceMonitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "splunk-kubernetes-logging.name" . }}
+      release: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  endpoints:
+  - port: http-metrics
+    {{- if .Values.global.serviceMonitor.interval }}
+    interval: {{ .Values.global.serviceMonitor.interval }}
+    {{- end }}
+    {{- if .Values.global.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.global.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+{{- end }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -325,7 +325,7 @@ image:
 environmentVar:
 
 # Pod annotations for daemonset
-podAnnotations: 
+podAnnotations:
 
 # Controls the resources used by the fluentd daemonset
 resources:
@@ -474,3 +474,12 @@ global:
     clusterName: "cluster_name"
   prometheus_enabled: true
   monitoring_agent_enabled: true
+  # deploy a ServiceMonitor object for usage of the PrometheusOperator
+  serviceMonitor:
+    enabled: false
+
+    metricsPort: 24231
+    interval: ""
+    scrapeTimeout: "10s"
+
+    additionalLabels: {}

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -44,6 +44,15 @@ global:
     clusterName: "cluster_name"
   prometheus_enabled:
   monitoring_agent_enabled:
+  # deploy a ServiceMonitor object for usage of the PrometheusOperator
+  serviceMonitor:
+    enabled: false
+
+    metricsPort: 24231
+    interval: ""
+    scrapeTimeout: "10s"
+
+    additionalLabels: { }
 
 ## Enabling splunk-kubernetes-logging will install the `splunk-kubernetes-logging` chart to a kubernetes
 ## cluster to collect logs generated in the cluster to a Splunk indexer/indexer cluster.


### PR DESCRIPTION
## Proposed changes

At the moment Prometheus metrics are set up with the legacy method for target detection.     
This pull request allows to optionally deploy a ServiceMonitor object which can be picked up by an Prometheus operator.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

