### PR TITLE
Fluentd logging Pod Configurable checkpoint file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Helm, maintained by the CNCF, allows the Kubernetes administrator to install, up
 To install and configure defaults with Helm:
 
 ```
-$ helm install --name my-release -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.2.0/splunk-connect-for-kubernetes-1.2.0.tgz
+$ helm install --name my-release -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.4.0/splunk-connect-for-kubernetes-1.4.0.tgz
 ```
 
 To learn more about using and modifying charts, see:

--- a/helm-chart/splunk-connect-for-kubernetes/README.md
+++ b/helm-chart/splunk-connect-for-kubernetes/README.md
@@ -17,7 +17,7 @@ First, prepare a Values file. Check the Values files in each sub-chart for detai
 Once you have a Values file, you can simply install the chart with a release name (optional) by running
 
 ```bash
-$ helm install --name my-splunk-connect -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.2.0/splunk-connect-for-kubernetes-1.2.0.tgz
+$ helm install --name my-splunk-connect -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.4.0/splunk-connect-for-kubernetes-1.4.0.tgz
 ```
 
 ## Uninstall ##

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/README.md
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/README.md
@@ -17,7 +17,7 @@ First, prepare a values file. You can also check the [examples](examples) for qu
 Once you have a values file, you can simply install the chart with a release name (optional) by running
 
 ```bash
-$ helm install --name my-splunk-logging -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.2.0/splunk-kubernetes-logging-1.2.0.tgz
+$ helm install --name my-splunk-logging -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.4.0/splunk-kubernetes-logging-1.4.0.tgz
 ```
 
 ## Uninstall ##

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -79,7 +79,7 @@ data:
       {{- if .Values.fluentd.exclude_path }}
       exclude_path {{ .Values.fluentd.exclude_path | toJson }}
       {{- end }}
-      pos_file /var/log/splunk-fluentd-containers.log.pos
+      pos_file {{ $.Values.fluentd.checkpointFile.path }}/splunk-fluentd-containers.log.pos
       path_key source
       read_from_head true
       <parse>
@@ -109,7 +109,7 @@ data:
       @label @SPLUNK
       tag tail.file.{{ or $logDef.sourcetype $name }}
       path {{ $logDef.from.file.path }}
-      pos_file /var/log/splunk-fluentd-{{ $name }}.pos
+      pos_file {{ $.Values.fluentd.checkpointFile.path }}/splunk-fluentd-{{ $name }}.pos
       read_from_head true
       path_key source
       {{- if $logDef.multiline }}
@@ -157,7 +157,7 @@ data:
       <storage>
         @type local
         persistent true
-        path /var/log/splunkd-fluentd-journald-{{ $name }}.pos.json
+        path {{ $.Values.fluentd.checkpointFile.path }}/splunkd-fluentd-journald-{{ $name }}.pos.json
       </storage>
       <entry>
         field_map {"MESSAGE": "log", "_SYSTEMD_UNIT": "source"}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -282,7 +282,7 @@ image:
   # The name of the image to pull
   name: splunk/fluentd-hec
   # The tag of the image to pull
-  tag: 1.2.0
+  tag: 1.2.1
   # The policy that specifies when the user wants the images to be pulled
   pullPolicy: Always
   # Indicates if the image should be pulled using authentication from a secret

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -19,6 +19,9 @@ fluentd:
   exclude_path:
   #  - /var/log/containers/kube-svc-redirect*.log
   #  - /var/log/containers/tiller*.log
+  checkpointFile:
+    # the name of the checkpoint file.
+    path: /var/log/fluentd
 
 # Configurations for container logs
 containers:

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/README.md
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/README.md
@@ -17,7 +17,7 @@ Then, prepare a values file. You can also check the [examples](examples) for qui
 Once you have a values file, you can simply install the chart with a release name (optional) by running
 
 ```bash
-$ helm install --name my-splunk-metrics -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.2.0/splunk-kubernetes-metrics-1.2.0.tgz
+$ helm install --name my-splunk-metrics -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.4.0/splunk-kubernetes-metrics-1.4.0.tgz
 
 ```
 

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
@@ -76,7 +76,7 @@ image:
   # The name of the image to pull
   name: splunk/k8s-metrics
   # The tag of the image to pull
-  tag: 1.1.2
+  tag: 1.1.3
   # The policy that specifies when the user wants the images to be pulled
   pullPolicy: Always
   # Indicates if the image should be pulled using authentication from a secret
@@ -91,7 +91,7 @@ imageAgg:
   # The name of the image to pull
   name: splunk/k8s-metrics-aggr
   # The tag of the image to pull
-  tag: 1.1.1
+  tag: 1.1.2
   # The policy that specifies when the user wants the images to be pulled
   pullPolicy: Always
   # Indicates if the image should be pulled using authentication from a secret

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/README.md
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/README.md
@@ -17,7 +17,7 @@ First, prepare a values file. You can also check the [examples](examples) for qu
 Once you have a values file, you can simply install the chart with a release name (optional) by running
 
 ```bash
-$ helm install --name my-splunk-objects -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.2.0/splunk-kubernetes-objects-1.2.0.tgz
+$ helm install --name my-splunk-objects -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.4.0/splunk-kubernetes-objects-1.4.0.tgz
 ```
 
 ## Uninstall ##

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
@@ -173,7 +173,7 @@ image:
   # The name of the image to pull
   name: splunk/kube-objects
   # The tag of the image to pull
-  tag: 1.1.2
+  tag: 1.1.3
   # The policy that specifies when the user wants the images to be pulled
   pullPolicy: Always
   # Indicates if the image should be pulled using authentication from a secret

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -64,6 +64,10 @@ splunk-kubernetes-logging:
     exclude_path:
     #  - /var/log/containers/kube-svc-redirect*.log
     #  - /var/log/containers/tiller*.log
+    checkpointFile:
+    # the name of the checkpoint file.
+      path: /var/log/fluentd
+
 
   # Configurations for container logs
   containers:

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -320,7 +320,7 @@ splunk-kubernetes-logging:
     # The name of the image to pull
     name: splunk/fluentd-hec
     # The tag of the image to pull
-    tag: 1.1.1
+    tag: 1.2.1
     # The policy that specifies when the user wants the images to be pulled
     pullPolicy: Always
     # Indicates if the image should be pulled using authentication from a secret
@@ -606,7 +606,7 @@ splunk-kubernetes-objects:
     # The name of the image to pull
     name: splunk/kube-objects
     # The tag of the image to pull
-    tag: 1.1.2
+    tag: 1.1.3
     # The policy that specifies when the user wants the images to be pulled
     pullPolicy: Always
     # Indicates if the image should be pulled using authentication from a secret
@@ -776,7 +776,7 @@ splunk-kubernetes-metrics:
     # The name of the image to pull
     name: splunk/k8s-metrics
     # The tag of the image to pull
-    tag: 1.1.1
+    tag: 1.1.3
     # The policy that specifies when the user wants the images to be pulled
     pullPolicy: Always
     # Indicates if the image should be pulled using authentication from a secret
@@ -791,7 +791,7 @@ splunk-kubernetes-metrics:
     # The name of the image to pull
     name: splunk/k8s-metrics-aggr
     # The tag of the image to pull
-    tag: 1.1.0
+    tag: 1.1.2
     # The policy that specifies when the user wants the images to be pulled
     pullPolicy: Always
     # Indicates if the image should be pulled using authentication from a secret


### PR DESCRIPTION
## Proposed changes

Current fluentd configmap.yaml hardcode checkpoint file at /var/log/ directory directly. Enterprise organization security team do not allow to write directly on /var/log and SELinux policy need to customize for it. Its allowed if we can create directory within /var/log and write it there. This enhancement will provide option to specify checkpoint file path through value file.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

