### PR TITLE
add refresh_interval to source.containers.conf (#389)

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -94,6 +94,7 @@ data:
         time_key time
         time_type string
         localtime false
+        refresh_interval {{ .Values.containers.refreshInterval | default 60 }}
       </parse>
     </source>
 

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -31,6 +31,8 @@ containers:
   # Specify the log format for "cri" logFormatType
   # It can be "%Y-%m-%dT%H:%M:%S.%N%:z" for openshift and "%Y-%m-%dT%H:%M:%S.%NZ" for IBM IKS
   logFormat:
+  # Specify the interval of refreshing the list of watch file. 
+  refreshInterval:
 
 # Directory where to read journald logs. (docker daemon logs, kubelet logs, and anyother specified serivce logs)
 journalLogPath: /run/log/journal

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -76,6 +76,8 @@ splunk-kubernetes-logging:
     # Specify the log format for "cri" logFormatType
     # It can be "%Y-%m-%dT%H:%M:%S.%N%:z" for openshift and "%Y-%m-%dT%H:%M:%S.%NZ" for IBM IKS
     logFormat:
+    # Specify the interval of refreshing the list of watch file. 
+    refreshInterval:
 
   # Enriches log record with kubernetes data
   k8sMetadata:


### PR DESCRIPTION
## Proposed changes

This change add the ability to set refresh_interval and sets the default as 60s if not configured which is the fluentd default 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

