### PR TITLE
Allow splunk logging output json format

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -394,11 +394,17 @@ data:
         <format monitor_agent>
           @type json
         </format>
+        {{- if .Values.output_json_format }}
+        <format>
+          @type json
+        </format>
+        {{- else }}
         <format>
           # we just want to keep the raw logs, not the structure created by docker or journald
           @type single_value
           message_key log
           add_newline false
         </format>
+        {{- end }}
       </match>
     </label>

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -403,6 +403,10 @@ customFilters: {}
 # WARNING: The fields being used here must be available inside the fluentd record.
 indexFields: []
 
+# Default to false ( in the global ) and this will keep the raw logs, not the structure created by docker or journald
+# Set to true if you want use json format for outout.
+output_json_format: 
+
 # Global configurations
 # These configurations will be used if the corresponding local configurations are not set.
 # For example, if `global.logLevel` is set and `logLevel` is not set, `global.logLevel` will be used; if `logLevel` is set, it will be used regardless `global.logLevel` is set or not.
@@ -424,3 +428,4 @@ global:
   kubernetes:
     clusterName: "cluster_name"
   prometheus_enabled: true
+  output_json_format: false


### PR DESCRIPTION
## Proposed changes

Feature to allow user to choose either logging output in json format, or keep it in raw format. As of 1.4.1 version, it allows only to keep it in raw format. 

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

