### PR TITLE
Add the ability to specify annotations for custom metadata fields

### DIFF
--- a/.circleci/sck_values.yml
+++ b/.circleci/sck_values.yml
@@ -26,6 +26,9 @@ splunk-kubernetes-logging:
       value: customvalue1
     - name: customfield2
       value: customvalue2
+  customMetadataAnnotations:
+    - name: custom_field
+      annotation: splunk.com/custom-field
 
 splunk-kubernetes-metrics:
   kubernetes:

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/examples/mini_custom_metadata.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/examples/mini_custom_metadata.yaml
@@ -11,3 +11,8 @@ customMetadata:
     value: "1234567890"
   - name: "cloud_account_region"
     value: "us-west-2"
+
+customMetadataAnnotations:
+  # Adds an 'application' field with the value of the 'splunk.com/application-field' annotation
+  - name: "application"
+    annotation: "splunk.com/application-field"

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -248,6 +248,11 @@ data:
           {{ .name }} "{{ .value }}"
           {{- end }}
           {{- end }}
+          {{- if .Values.customMetadataAnnotations }}
+          {{- range .Values.customMetadataAnnotations }}
+          {{ .name }} ${record.dig("kubernetes","annotations","{{ .annotation }}") ? record.dig("kubernetes","annotations","{{ .annotation }}") : record.dig("kubernetes","namespace_annotations","{{ .annotation }}")}
+          {{- end }}
+          {{- end }}
         </record>
       </filter>
       <filter tail.containers.**>
@@ -375,6 +380,11 @@ data:
           {{- end }}
           {{- if .Values.customMetadata }}
           {{- range .Values.customMetadata }}
+          {{ .name }}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.customMetadataAnnotations }}
+          {{- range .Values.customMetadataAnnotations }}
           {{ .name }}
           {{- end }}
           {{- end }}

--- a/test/k8s_logging_tests/test_config_logging.py
+++ b/test/k8s_logging_tests/test_config_logging.py
@@ -264,6 +264,7 @@ def test_default_fields(setup, test_input, expected):
                 len(events))
     assert len(events) >= expected
 
+
 @pytest.mark.parametrize("field,value,expected", [
     ("customfield1", "customvalue1", 1),
     ("customfield2", "customvalue2", 1)
@@ -276,6 +277,31 @@ def test_custom_metadata_fields(setup, field,value, expected):
         field,value, expected))
     index_logging = os.environ["CI_INDEX_EVENTS"] if os.environ["CI_INDEX_EVENTS"] else "circleci_events"
     search_query = "index=" + index_logging + " " + field + "::" + value
+    events = check_events_from_splunk(start_time="-1h@h",
+                                      url=setup["splunkd_url"],
+                                      user=setup["splunk_user"],
+                                      query=["search {0}".format(
+                                          search_query)],
+                                      password=setup["splunk_password"])
+    logger.info("Splunk received %s events in the last minute",
+                len(events))
+    assert len(events) >= expected
+
+
+@pytest.mark.parametrize("label,value,expected", [
+    ("pod-w-index-wo-ns-index", "pod-value-2", 1),
+    ("pod-wo-index-w-ns-index", "ns-value", 1),
+    ("pod-w-index-w-ns-index", "pod-value-1", 1)
+])
+def test_custom_metadata_fields_annotations(setup, label, value, expected):
+    '''
+    Test that user specified labels are resolved from the user specified annotations and attached as a metadata
+    to all the logs
+    '''
+    logger.info("testing custom metadata annotation label={0} value={1} expected={2} event(s)".format(
+        label, value, expected))
+    index_logging = os.environ["CI_INDEX_EVENTS"] if os.environ["CI_INDEX_EVENTS"] else "circleci_events"
+    search_query = "index=" + index_logging + " label_app::" + label + " custom_field::" + value
     events = check_events_from_splunk(start_time="-1h@h",
                                       url=setup["splunkd_url"],
                                       user=setup["splunk_user"],

--- a/test/test_setup.yaml
+++ b/test/test_setup.yaml
@@ -5,6 +5,7 @@ metadata:
   name: ns-w-index
   annotations:
     splunk.com/index: ns-anno
+    splunk.com/custom-field: ns-value
 ---
 apiVersion: v1
 kind: Namespace
@@ -36,6 +37,7 @@ spec:
       annotations:
         splunk.com/index: "pod-anno"
         splunk.com/sourcetype: "sourcetype-anno"
+        splunk.com/custom-field: pod-value-1
     spec:
       containers:
       - name: pod-w-index-w-ns-index
@@ -82,6 +84,7 @@ spec:
         app: pod-w-index-wo-ns-index
       annotations:
         splunk.com/index: "pod-anno"
+        splunk.com/custom-field: pod-value-2
     spec:
       containers:
       - name: pod-w-index-wo-ns-index


### PR DESCRIPTION
## Proposed changes

I'd like to add an option to better customize fields in logging events by defining mappings between annotations that can be specified on a pod or namespace, and the corresponding field name it will be mapped to in Splunk.  This would allow for fairly flexible usage of annotations in kubernetes to enhance logging events with custom field values.

Issue: https://github.com/splunk/splunk-connect-for-kubernetes/issues/393

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

