### PR TITLE
Fix install/uninstall commands for Helm 3 (#406)

### DIFF
--- a/.circleci/deploy_connector.sh
+++ b/.circleci/deploy_connector.sh
@@ -11,10 +11,10 @@ echo "Checking if previous deployment exist..."
 if [ "`helm ls`" == "" ]; then
    echo "Nothing to clean, ready for deployment"
 else
-   helm delete --purge $(helm ls --short)
+   helm delete $(helm ls --short)
 fi
 echo "Deploying k8s-connect with latest changes"
-helm install --name=ci-sck -f .circleci/sck_values.yml helm-artifacts/splunk-connect-for-kubernetes*.tgz
+helm install ci-sck -f .circleci/sck_values.yml helm-artifacts/splunk-connect-for-kubernetes*.tgz
 #wait for deployment to finish
 until kubectl get pod | grep Running | [[ $(wc -l) == 4 ]]; do
    sleep 1;

--- a/.circleci/performance/perf_deploy_sck.sh
+++ b/.circleci/performance/perf_deploy_sck.sh
@@ -29,7 +29,7 @@ function deploy_sck ()
     print_msg "Deploying SCK"
     setup_kubeclient || true
     print_msg "Installing the SCK build artifacts on the kubernetes cluster"
-    helm install --name=perf-test -f .circleci/performance/perf_test_sck_values.yml helm-artifacts/splunk-connect-for-kubernetes*.tgz
+    helm install perf-test -f .circleci/performance/perf_test_sck_values.yml helm-artifacts/splunk-connect-for-kubernetes*.tgz
 }
 
 function clean_sck ()
@@ -38,7 +38,7 @@ function clean_sck ()
     if [ "`helm ls`" == "" ]; then
        print_msg "Nothing to clean, ready for deployment"
     else
-       helm delete --purge $(helm ls --short)
+       helm delete $(helm ls --short)
     fi
 }
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Helm, maintained by the CNCF, allows the Kubernetes administrator to install, up
 To install and configure defaults with Helm:
 
 ```
-$ helm install --name my-release -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.4.1/splunk-connect-for-kubernetes-1.4.1.tgz
+$ helm install my-release -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.4.1/splunk-connect-for-kubernetes-1.4.1.tgz
 ```
 
 To learn more about using and modifying charts, see:

--- a/helm-chart/splunk-connect-for-kubernetes/README.md
+++ b/helm-chart/splunk-connect-for-kubernetes/README.md
@@ -17,7 +17,7 @@ First, prepare a Values file. Check the Values files in each sub-chart for detai
 Once you have a Values file, you can simply install the chart with a release name (optional) by running
 
 ```bash
-$ helm install --name my-splunk-connect -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.4.1/splunk-connect-for-kubernetes-1.4.1.tgz
+$ helm install my-splunk-connect -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.4.1/splunk-connect-for-kubernetes-1.4.1.tgz
 ```
 
 ## Uninstall ##
@@ -25,7 +25,7 @@ $ helm install --name my-splunk-connect -f my_values.yaml https://github.com/spl
 To uninstall/delete deployment with name `my-splunk-connect`:
 
 ```bash
-$ helm delete --purge my-splunk-connect
+$ helm delete my-splunk-connect
 ```
 
 The command removes all the Kubernetes components associated with the Chart and deletes the release.

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/README.md
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/README.md
@@ -17,7 +17,7 @@ First, prepare a values file. You can also check the [examples](examples) for qu
 Once you have a values file, you can simply install the chart with a release name (optional) by running
 
 ```bash
-$ helm install --name my-splunk-logging -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.4.1/splunk-kubernetes-logging-1.4.1.tgz
+$ helm install my-splunk-logging -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.4.1/splunk-kubernetes-logging-1.4.1.tgz
 ```
 
 ## Uninstall ##
@@ -25,7 +25,7 @@ $ helm install --name my-splunk-logging -f my_values.yaml https://github.com/spl
 To uninstall/delete a deployment with name `my-splunk-logging`:
 
 ```bash
-$ helm delete --purge my-splunk-logging
+$ helm delete my-splunk-logging
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/README.md
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/README.md
@@ -17,7 +17,7 @@ Then, prepare a values file. You can also check the [examples](examples) for qui
 Once you have a values file, you can simply install the chart with a release name (optional) by running
 
 ```bash
-$ helm install --name my-splunk-metrics -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.4.1/splunk-kubernetes-metrics-1.4.1.tgz
+$ helm install my-splunk-metrics -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.4.1/splunk-kubernetes-metrics-1.4.1.tgz
 
 ```
 
@@ -26,7 +26,7 @@ $ helm install --name my-splunk-metrics -f my_values.yaml https://github.com/spl
 To uninstall/delete a deployment with name `my-splunk-metrics`:
 
 ```bash
-$ helm delete --purge my-splunk-metrics
+$ helm delete my-splunk-metrics
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/README.md
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/README.md
@@ -17,7 +17,7 @@ First, prepare a values file. You can also check the [examples](examples) for qu
 Once you have a values file, you can simply install the chart with a release name (optional) by running
 
 ```bash
-$ helm install --name my-splunk-objects -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.4.1/splunk-kubernetes-objects-1.4.1.tgz
+$ helm install my-splunk-objects -f my_values.yaml https://github.com/splunk/splunk-connect-for-kubernetes/releases/download/1.4.1/splunk-kubernetes-objects-1.4.1.tgz
 ```
 
 ## Uninstall ##
@@ -25,7 +25,7 @@ $ helm install --name my-splunk-objects -f my_values.yaml https://github.com/spl
 To uninstall/delete a deployment with name `my-splunk-objects`:
 
 ```bash
-$ helm delete --purge my-splunk-objects
+$ helm delete my-splunk-objects
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.


### PR DESCRIPTION
Helm 2 flags are not compatible with Helm 3.

## Proposed changes

Update Helm commands for installing/unstalling to use Helm 3 syntax.  See issue #406.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [N/A] Any dependent changes have been merged and published in downstream modules
