### PR TITLE
Optional disabling AppArmor annotations

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/podSecurityPolicy.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/podSecurityPolicy.yaml
@@ -10,9 +10,11 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    {{- if .Values.podSecurityPolicy.apparmor_security }}
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    {{- end }}
 spec:
   privileged: true
   allowPrivilegeEscalation: true

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -108,6 +108,12 @@ podSecurityPolicy:
   # a) Pod Security Policies is not enabled in the cluster, or
   # b) you want to create Pod Security Policy resources by yourself.
   create: false
+  # Specifies whether AppArmor profile should be applied.
+  # if set to true, this will add two annotations to PodSecurityPolicy:
+  # apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+  # apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+  # set to false if AppArmor is not available
+  apparmor_security: true
 
 # Create or use existing secret if name is empty default name is used
 secret:

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/podSecurityPolicy.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/podSecurityPolicy.yaml
@@ -10,9 +10,11 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    {{- if .Values.podSecurityPolicy.apparmor_security }}
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    {{- end }}
 spec:
   privileged: false
   allowPrivilegeEscalation: false

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
@@ -34,6 +34,12 @@ podSecurityPolicy:
   # a) Pod Security Policies is not enabled in the cluster, or
   # b) you want to create Pod Security Policy resources by yourself.
   create: false
+  # Specifies whether AppArmor profile should be applied.
+  # if set to true, this will add two annotations to PodSecurityPolicy:
+  # apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+  # apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+  # set to false if AppArmor is not available
+  apparmor_security: true
 
 # = Splunk HEC Connection =
 splunk:

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/podSecurityPolicy.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/podSecurityPolicy.yaml
@@ -10,9 +10,11 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
-    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
     seccomp.security.alpha.kubernetes.io/defaultProfileName:  'runtime/default'
+    {{- if .Values.podSecurityPolicy.apparmor_security }}
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    {{- end }}
 spec:
   privileged: false
   allowPrivilegeEscalation: false

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
@@ -36,6 +36,12 @@ podSecurityPolicy:
   # a) Pod Security Policies is not enabled in the cluster, or
   # b) you want to create Pod Security Policy resources by yourself.
   create: false
+  # Specifies whether AppArmor profile should be applied.
+  # if set to true, this will add two annotations to PodSecurityPolicy:
+  # apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+  # apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+  # set to false if AppArmor is not available
+  apparmor_security: true
 
 # = Kubernetes Connection Configs =
 kubernetes:

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -97,6 +97,19 @@ splunk-kubernetes-logging:
     # which will be used to get the images from a private registry
     usePullSecrets: false
 
+  podSecurityPolicy:
+    # Specifies whether Pod Security Policy resources should be created.
+    # This should be set to `false` if either:
+    # a) Pod Security Policies is not enabled in the cluster, or
+    # b) you want to create Pod Security Policy resources by yourself.
+    create: false
+    # Specifies whether AppArmor profile should be applied.
+    # if set to true, this will add two annotations to PodSecurityPolicy:
+    # apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    # apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    # set to false if AppArmor is not available
+    apparmor_security: true
+
   # Local splunk configurations
   splunk:
     # Configurations for HEC (HTTP Event Collector)
@@ -470,6 +483,19 @@ splunk-kubernetes-objects:
     # which will be used to get the images from a private registry
     usePullSecrets: false
 
+  podSecurityPolicy:
+    # Specifies whether Pod Security Policy resources should be created.
+    # This should be set to `false` if either:
+    # a) Pod Security Policies is not enabled in the cluster, or
+    # b) you want to create Pod Security Policy resources by yourself.
+    create: false
+    # Specifies whether AppArmor profile should be applied.
+    # if set to true, this will add two annotations to PodSecurityPolicy:
+    # apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    # apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    # set to false if AppArmor is not available
+    apparmor_security: true
+
   # = Kubernetes Connection Configs =
   kubernetes:
     # the URL for calling kubernetes API, by default it will be read from the environment variables
@@ -736,6 +762,19 @@ splunk-kubernetes-metrics:
     # This flag specifies if the user wants to use a secret for creating the serviceAccount,
     # which will be used to get the images from a private registry
     usePullSecrets: false
+
+  podSecurityPolicy:
+    # Specifies whether Pod Security Policy resources should be created.
+    # This should be set to `false` if either:
+    # a) Pod Security Policies is not enabled in the cluster, or
+    # b) you want to create Pod Security Policy resources by yourself.
+    create: false
+    # Specifies whether AppArmor profile should be applied.
+    # if set to true, this will add two annotations to PodSecurityPolicy:
+    # apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    # apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    # set to false if AppArmor is not available
+    apparmor_security: true
 
   # = Splunk HEC Connection =
   splunk:


### PR DESCRIPTION
## Proposed changes

In some cases, AppArmor is not available, for example on CentOS nodes, therefore it should be possible to skip AppArmor annotations.

## Types of changes
What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

