### PR TITLE
fix source.containers.conf path json array issue

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -75,7 +75,7 @@ data:
       @type tail
       @label @CONCAT
       tag tail.containers.*
-      path {{ .Values.fluentd.path | default "/var/log/containers/*.log" }}
+      path {{ .Values.fluentd.path | default "/var/log/containers/*.log" | toJson }}
       {{- if .Values.fluentd.exclude_path }}
       exclude_path {{ .Values.fluentd.exclude_path | toJson }}
       {{- end }}


### PR DESCRIPTION
## Proposed changes
Convert the `path` variable to JSON so fluentd doesn't crash when an array of paths is entered.
The same solution is already implemented for exlude_path.

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules