### PR TITLE
Feature image pull secrets

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/daemonset.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/daemonset.yaml
@@ -40,6 +40,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      {{ if .Values.image.usePullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.image.pullSecretName }}
+      {{ end }}
       containers:
       - name: splunk-fluentd-k8s-logs
         image: {{ template "splunk-kubernetes-logging.image" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/serviceAccount.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/serviceAccount.yaml
@@ -1,9 +1,5 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
-{{ if .Values.image.usePullSecret }}
-imagePullSecrets:
-- name: {{ .Values.image.pullSecretName }}
-{{ end }}
 kind: ServiceAccount
 metadata:
   name: {{ template "splunk-kubernetes-logging.serviceAccountName" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
@@ -41,6 +41,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      {{- if .Values.image.usePullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.image.pullsecretName}}
+      {{- end }}
       containers:
       - name: splunk-fluentd-k8s-metrics
         image: {{ template "splunk-kubernetes-metrics.image" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/serviceAccount.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/serviceAccount.yaml
@@ -1,9 +1,5 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
-{{ if .Values.image.usePullSecret }}
-imagePullSecrets:
-- name: {{ .Values.image.pullSecretName }}
-{{ end }}
 kind: ServiceAccount
 metadata:
   name: {{ template "splunk-kubernetes-metrics.serviceAccountName" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/deployment.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      {{ if .Values.image.usePullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.image.pullSecretName }}
+      {{ end }}
       containers:
       - name: splunk-fluentd-k8s-objects
         image: {{ template "splunk-kubernetes-objects.image" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/serviceAccount.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/serviceAccount.yaml
@@ -1,9 +1,5 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
-{{ if .Values.image.usePullSecret }}
-imagePullSecrets:
-- name: {{ .Values.image.pullSecretName }}
-{{ end }}
 kind: ServiceAccount
 metadata:
   name: {{ template "splunk-kubernetes-objects.serviceAccountName" . }}


### PR DESCRIPTION
## Proposed changes

This merge is intended to fix the missing "imagePullSecret" issue occurring in the Helm chart deployments.
Before this fix, the only place having the correct "imagePullSecret" is at the deployment of "metric aggregation". All the rest Helm charts of deployments and daemonsets have "imagePullSecret" missing because the "imagePullSecret" in them are located in the ServiceAccount creation. If the SeviceAccount condition is not met, the "imagePullSecret" would not be included in the deployments, which may cause the deployment fails if the image is pulled through a Docker registry secret.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

