### PR TITLE
Optionally manage the privileged SCC ClusterRoleBinding for OpenShift

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/clusterRoleBindingPrivilegedScc.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/clusterRoleBindingPrivilegedScc.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.openshiftPrivilegedSccBinding -}}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "splunk-kubernetes-logging.fullname" . }}-scc
+  labels:
+    app: {{ template "splunk-kubernetes-logging.name" . }}
+    chart: {{ template "splunk-kubernetes-logging.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:scc:privileged
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: {{ template "splunk-kubernetes-logging.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -103,6 +103,11 @@ rbac:
   # a) RBAC is not enabled in the cluster, or
   # b) you want to create RBAC resources by yourself.
   create: true
+  # If you are on OpenShift and you want to run the a privileged pod
+  # you need to have a ClusterRoleBinding for the system:openshift:scc:privileged
+  # ClusterRole. Set to `true` to create the ClusterRoleBinding resource
+  # for the ServiceAccount.
+  openshiftPrivilegedSccBinding: false
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -97,6 +97,11 @@ splunk-kubernetes-logging:
     # a) RBAC is not enabled in the cluster, or
     # b) you want to create RBAC resources by yourself.
     create: true
+    # If you are on OpenShift and you want to run the a privileged pod
+    # you need to have a ClusterRoleBinding for the system:openshift:scc:privileged
+    # ClusterRole. Set to `true` to create the ClusterRoleBinding resource
+    # for the ServiceAccount.
+    openshiftPrivilegedSccBinding: false
 
   serviceAccount:
     # Specifies whether a ServiceAccount should be created


### PR DESCRIPTION
## Proposed changes

On OpenShift ServiceAccounts that run privileged containers need
to have the privileged SCC ClusterRoleBinding.

Set `splunk-kubernetes-logging.rbac.openshiftPrivilegedSccBinding=true`
to manage this required resource on OpenShift.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

