### PR TITLE
Fix metrics collection when PodSecurityPolicies are enabled

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/clusterRole.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/clusterRole.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
 rules:
 {{- if .Values.podSecurityPolicy.create }}
-- apiGroups:      ['extensions']
+- apiGroups:      [{{ .Values.podSecurityPolicy.apiGroup | quote }}]
   resources:      ['podsecuritypolicies']
   verbs:          ['use']
   resourceNames:  [{{ template "splunk-kubernetes-logging.fullname" . }}]

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/clusterRole.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/clusterRole.yaml
@@ -11,7 +11,7 @@ metadata:
     heritage: {{ .Release.Service }}
 rules:
 {{- if .Values.podSecurityPolicy.create }}
-- apiGroups:      ['extensions']
+- apiGroups:      [{{ .Values.podSecurityPolicy.apiGroup | quote }}]
   resources:      ['podsecuritypolicies']
   verbs:          ['use']
   resourceNames:  [{{ template "splunk-kubernetes-metrics.fullname" . }}]

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/clusterRoleAggregator.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/clusterRoleAggregator.yaml
@@ -11,7 +11,7 @@ metadata:
     heritage: {{ .Release.Service }}
 rules:
 {{- if .Values.podSecurityPolicy.create }}
-- apiGroups:      ['extensions']
+- apiGroups:      [{{ .Values.podSecurityPolicy.apiGroup | quote }}]
   resources:      ['podsecuritypolicies']
   verbs:          ['use']
   resourceNames:  [{{ template "splunk-kubernetes-metrics.fullname" . }}-agg]

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
@@ -67,6 +67,8 @@ spec:
             value: /fluentd/etc/splunk/hec_ca_file
         resources:
 {{ toYaml .Values.resources.fluent | indent 12 }}
+        securityContext:
+          runAsNonRoot: false
         volumeMounts:
           - name: conf-configmap
             mountPath: /fluentd/etc

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
@@ -59,6 +59,8 @@ spec:
             value: /fluentd/etc/splunk/hec_ca_file
         resources:
 {{ toYaml .Values.resources.fluent | indent 12 }}
+        securityContext:
+          runAsNonRoot: false
         volumeMounts:
           - name: conf-configmap
             mountPath: /fluentd/etc

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/clusterRole.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/clusterRole.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
 rules:
   {{- if .Values.podSecurityPolicy.create }}
-  - apiGroups:      ['extensions']
+  - apiGroups:      [{{ .Values.podSecurityPolicy.apiGroup | quote }}]
     resources:      ['podsecuritypolicies']
     verbs:          ['use']
     resourceNames:  [{{ template "splunk-kubernetes-objects.fullname" . }}]

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/deployment.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
             value: /fluentd/etc/splunk/hec_ca_file
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        securityContext:
+          runAsNonRoot: false
         volumeMounts:
         - name: conf-configmap
           mountPath: /fluentd/etc

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -126,6 +126,8 @@ splunk-kubernetes-logging:
     # apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
     # set to false if AppArmor is not available
     apparmor_security: true
+    # apiGroup can be set to "extensions" for Kubernetes < 1.10.
+    apiGroup: policy
 
   # Local splunk configurations
   splunk:
@@ -535,6 +537,8 @@ splunk-kubernetes-objects:
     # apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
     # set to false if AppArmor is not available
     apparmor_security: true
+    # apiGroup can be set to "extensions" for Kubernetes < 1.10.
+    apiGroup: policy
 
   # = Kubernetes Connection Configs =
   kubernetes:
@@ -816,6 +820,8 @@ splunk-kubernetes-metrics:
     # apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
     # set to false if AppArmor is not available
     apparmor_security: true
+    # apiGroup can be set to "extensions" for Kubernetes < 1.10.
+    apiGroup: policy
 
   # = Splunk HEC Connection =
   splunk:


### PR DESCRIPTION
## Proposed changes

These commits restore the collection of non-aggregated metrics when PodSecurityPolicies are enabled.

The PodSecurityPolicy API was moved from the extensions to the policy group back in 1.10; support for extensions was removed in 1.16.

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

The second commit sets runAsNonRoot to an explicit false to allow the metrics and objects pods/containers to start successfully for a cluster with a default RunAsNonRoot PodSecurityPolicy rule.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [X] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [X] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged and published in downstream modules

