### PR TITLE
Support PodMonitor resources for prometheus scraping

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/daemonset.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/daemonset.yaml
@@ -103,6 +103,12 @@ spec:
       - name: secrets
         secret:
           secretName: {{ template "splunk-kubernetes-logging.secret" . }}
+      {{- if .Values.global.prometheus_enabled }}
+      ports:
+      - containerPort: 24231
+        name: metrics
+        protocol: TCP
+      {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}


### PR DESCRIPTION
## Proposed changes

When setting `global.prometheus_enabled=true` the logging DaemonSet
doesn't include the metrics port. Only the annotations are added.

The Prometheus operator has PodMontor resources to define scraping
configuration. It's required to have named ports defined on the
container.

Example PodMonitor resource for splunk-kubernetes-logging:

```yaml
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  name: splunk-kubernetes-logging
spec:
  selector:
    matchLabels:
      app: splunk-kubernetes-logging
  podMetricsEndpoints:
  - port: metrics
    interval: 30s
```

There is a `targetPort` property too that would accept a
integer port. But it's marked as deprecated and also it didn't work
(invalid scraping config generated).

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

