### PR TITLE
Change default encoding to UTF-8 (in configMap.yaml)

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -73,6 +73,8 @@ data:
     # CRI Log Example (not supported):
     # 2016-02-17T00:04:05.931087621Z stdout [info:2016-02-16T16:04:05.930-08:00] Some log text here
     <source>
+      encoding UTF-8
+      from_encoding UTF-8
       @id containers.log
       @type tail
       @label @CONCAT


### PR DESCRIPTION
## Proposed changes

Change default ASCII-8BIT encoding to UTF-8
splunk-connect-for-kubernetes/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml:
add after line 75 
(https://github.com/splunk/splunk-connect-for-kubernetes/blob/79d17645af594762c9421cc184d59201a7ccb0a6/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml#L75):
encoding UTF-8
from_encoding UTF-8

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

