### PR TITLE
Option to encode strings as utf-8: charEncodingUtf8

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -184,6 +184,13 @@ data:
   output.conf: |-
     #Events are emitted to the CONCAT label from the container, file and journald sources for multiline processing.
     <label @CONCAT>
+      {{- if .Values.charEncodingUtf8 }}
+      # = set strings to uft-8 encoding =
+      <filter **>
+        @type record_modifier
+        char_encoding utf-8
+      </filter>
+      {{- end }}
       # = filters for container logs =
       {{- range $name, $logDef := .Values.logs }}
       {{- if and $logDef.from.pod $logDef.multiline }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -132,6 +132,13 @@ secret:
   create: true
   name:
 
+# Set to true, to change the encoding of all strings to utf-8.
+#
+# By default fluentd uses ASCII-8BIT encoding. If you have 2-byte chars in your logs
+# you need to set the encoding to UTF-8 instead.
+#
+charEncodingUtf8: false
+
 # `logs` defines the source of logs, multiline support, and their sourcetypes.
 #
 # The scheme to define a log is:

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -176,6 +176,13 @@ splunk-kubernetes-logging:
   # Directory where to read journald logs.
   journalLogPath: /run/log/journal
 
+  # Set to true, to change the encoding of all strings to utf-8.
+  #
+  # By default fluentd uses ASCII-8BIT encoding. If you have 2-byte chars in your logs
+  # you need to set the encoding to UTF-8 instead.
+  #
+  charEncodingUtf8: false
+
   # `logs` defines the source of logs, multiline support, and their sourcetypes.
   #
   # The scheme to define a log is:


### PR DESCRIPTION
## Proposed changes

By default fluentd uses ASCII-8BIT encoding internally by default
because it also could handle binary log types.

If you have 2-byte UTF-8 chars in your logs, you should enable
the option to set the encoding to UTF-8.

See issue #568

Based on the PR https://github.com/openshift/origin-aggregated-logging/pull/622

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

