### PR TITLE
Add unsupported note to YAML deployment method

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ To learn more about using and modifying charts, see:
 * [The values file for metrics](https://github.com/splunk/splunk-connect-for-kubernetes/blob/main/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml)
 * [The values file for objects](https://github.com/splunk/splunk-connect-for-kubernetes/blob/main/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml)
 
-## Deploy using YAML
+## Deploy using YAML (unsupported)
+
+> Only deploying by Helm is supported by Splunk.
 
 You can grab the manifest YAML files and use them to create the Kubernetes objects needed to deploy Splunk Connect for Kubernetes. Please note that installation and debugging for Splunk Connect for Kubernetes through YAML is community-supported only.
 


### PR DESCRIPTION
## Proposed changes

It's already noted in the text of the helm deployment method, but
every YAML reader should be aware that it's not a supported
method of installing.

https://github.com/splunk/splunk-connect-for-kubernetes/issues/571
https://github.com/splunk/splunk-connect-for-kubernetes/issues/565

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

