### PR TITLE
Fix typo in image.pullSecretName variable for splunk-kubernetes-logging

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -116,9 +116,6 @@ serviceAccount:
   # The name of the ServiceAccount to use.
   # If not set and create is true, a name is generated using the fullname template
   name:
-  # This flag specifies if the user wants to use a secret for creating the serviceAccount,
-  # which will be used to get the images from a private registry
-  usePullSecrets: false
 
 podSecurityPolicy:
   # Specifies whether Pod Security Policy resources should be created.

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -321,7 +321,7 @@ image:
   # Indicates if the image should be pulled using authentication from a secret
   usePullSecret: false
   # The name of the pull secret to attach to the respective serviceaccount used to pull the image
-  pullsecretName:
+  pullSecretName:
 
 # Environment variable for daemonset
 environmentVar:

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -367,7 +367,7 @@ splunk-kubernetes-logging:
     # Indicates if the image should be pulled using authentication from a secret
     usePullSecret: false
     # The name of the pull secret to attach to the respective serviceaccount used to pull the image
-    pullsecretName:
+    pullSecretName:
 
   # Environment variable for daemonset
   environmentVar:

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -110,9 +110,6 @@ splunk-kubernetes-logging:
     # The name of the ServiceAccount to use.
     # If not set and create is true, a name is generated using the fullname template
     name:
-    # This flag specifies if the user wants to use a secret for creating the serviceAccount,
-    # which will be used to get the images from a private registry
-    usePullSecrets: false
 
   podSecurityPolicy:
     # Specifies whether Pod Security Policy resources should be created.


### PR DESCRIPTION
## Proposed changes

* fix typo in values.yaml for splunk-kubernetes-logging (closes #583)
* remove unused serviceAccount.usePullSecrets variable for splunk-kubernetes-logging

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

