### PR TITLE
Fixes Issue #633. Tightens the regular expression for the logFormatType=cri causing log clipping

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -90,7 +90,7 @@ data:
       <parse>
       {{- if eq .Values.containers.logFormatType "cri" }}
         @type regexp
-        expression /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
+        expression /^(?<time>[^\s]+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
         time_format  {{ .Values.containers.logFormat | default "%Y-%m-%dT%H:%M:%S.%N%:z" }}
       {{- else if eq .Values.containers.logFormatType "json" }}
         @type json


### PR DESCRIPTION
Fixes Issue #633. Tightens the regular expression for the logFormatType=cri  to prevent time field from absorbing arbitrary portions of the log line.

To see this in action simply use this example text:

 `2016-02-17T00:04:05.931087621Z stdout F this part of the log entry gets clipped stderr F foobar`

 
 And the broken regex here:
 ` ^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$`

 
 You'll see that the regular expression will match the last reference to "stdout" or "stderr" causing anything between the extra stdout/stderr to be clipped and not included in the log line.
 
 When changed to the suggested regex:
`^(?<time>[^\s]+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$`
 
 Extra log values are not clipped and the second entry contains the full log property
 
 

## Proposed changes

This regular expression change tightens the match down to just a single word item preventing it from matching across white space to other words.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

