### PR TITLE
Include priorityClassName for splunk-kubernetes-objects

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/deployment.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/deployment.yaml
@@ -100,3 +100,6 @@ spec:
       - name: checkpoints
 {{ toYaml .Values.checkpointFile.volume | indent 8 }}
       {{- end -}}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
@@ -43,6 +43,9 @@ podSecurityPolicy:
   # set to false if AppArmor is not available
   apparmor_security: true
 
+# Defines priorityClassName to assign a priority class to pods.
+priorityClassName:
+
 # = Kubernetes Connection Configs =
 kubernetes:
   # the URL for calling kubernetes API, by default it will be read from the environment variables

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -557,6 +557,9 @@ splunk-kubernetes-objects:
     # apiGroup can be set to "extensions" for Kubernetes < 1.10.
     apiGroup: policy
 
+  # Defines priorityClassName to assign a priority class to pods.
+  priorityClassName:
+
   # = Kubernetes Connection Configs =
   kubernetes:
     # the URL for calling kubernetes API, by default it will be read from the environment variables


### PR DESCRIPTION
## Proposed changes

This change Defines priorityClassName to assign a priority class to splunk-kubernetes-objects  pods.

we are planning to implement pod priority to monitoring and logging deployments and daemonsets. the current version does not support that for splunk-kubernetes-objects  deployment.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

