### PR TITLE
enable monitoring agent for all pods and add liveness probes

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -13,9 +13,7 @@ data:
     @include source.containers.conf
     @include source.files.conf
     @include source.journald.conf
-    {{- if .Values.global.monitoring_agent_enabled }}
     @include monit.conf
-    {{- end }}
     @include output.conf
     {{- if .Values.global.prometheus_enabled }}
     @include prometheus.conf
@@ -172,16 +170,15 @@ data:
     {{- end }}
     {{- end }}
 
-  {{- if .Values.global.monitoring_agent_enabled }}
   monit.conf: |-
     <source>
       @id fluentd-monitor-agent
       @type monitor_agent
       @label @SPLUNK
+      {{- if .Values.global.monitoring_agent_enabled }}
       tag monitor_agent
-    </source>
-  {{- end }}
-
+      {{- end }}
+    </source>  
 
   output.conf: |-
     #Events are emitted to the CONCAT label from the container, file and journald sources for multiline processing.
@@ -328,7 +325,7 @@ data:
       # = filters for monitor agent =
       <filter monitor_agent>
         @type jq_transformer
-        jq ".record.source = \"namespace:#{ENV['MY_NAMESPACE']}/pod:#{ENV['MY_POD_NAME']}\" | .record.sourcetype = \"fluentd:monitor-agent\" | .record.cluster_name = \"{{ or .Values.kubernetes.clusterName .Values.global.kubernetes.clusterName | default "cluster_name" }}\" | .record.splunk_index = \"{{ or .Values.global.splunk.hec.indexName .Values.splunk.hec.indexName | default "main" }}\" {{- if .Values.customMetadata }}{{- range .Values.customMetadata }}| .record.{{ .name }} = \"{{ .value }}\" {{- end }}{{- end }} | .record"
+        jq ".record.source = \"namespace:#{ENV['MY_NAMESPACE']}/pod:#{ENV['MY_POD_NAME']}\" | .record.sourcetype = \"fluentd:monitor-agent\" | .record.cluster_name = \"{{ or .Values.kubernetes.clusterName .Values.global.kubernetes.clusterName | default "cluster_name" }}\" | .record.splunk_index = \"{{ or .Values.global.monitoring_agent_index_name .Values.global.splunk.hec.indexName .Values.splunk.hec.indexName | default "main" }}\" {{- if .Values.customMetadata }}{{- range .Values.customMetadata }}| .record.{{ .name }} = \"{{ .value }}\" {{- end }}{{- end }} | .record"
       </filter>
       {{- end }}
       # = custom filters specified by users =

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/daemonset.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/daemonset.yaml
@@ -98,12 +98,23 @@ spec:
         - name: secrets
           mountPath: /fluentd/etc/splunk
           readOnly: true
-        {{- if .Values.global.prometheus_enabled }}
         ports:
+        {{- if .Values.global.prometheus_enabled }}
         - containerPort: 24231
           name: metrics
           protocol: TCP
         {{- end }}
+        {{- if .Values.global.monitoring_agent_enabled }}
+        - containerPort: 24220
+          name: monitor-agent
+          protocol: TCP
+        {{- end }}
+        livenessProbe:
+          httpGet:
+            path: /api/plugins.json
+            port: 24220
+          initialDelaySeconds: 60
+          periodSeconds: 60
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -475,6 +475,7 @@ global:
     clusterName: "cluster_name"
   prometheus_enabled: true
   monitoring_agent_enabled: true
+  monitoring_agent_index_name:
   # deploy a ServiceMonitor object for usage of the PrometheusOperator
   serviceMonitor:
     enabled: false

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/configMap.yaml
@@ -43,6 +43,38 @@ data:
       interval {{ . }}
       {{- end }}
     </source>
+
+    <source>
+      @id fluentd-monitor-agent
+      @type monitor_agent
+      {{- if .Values.global.monitoring_agent_enabled }}
+      tag monitor_agent
+      {{- end }}
+    </source>
+
+    {{- if .Values.global.monitoring_agent_enabled }}
+    # = filters for monitor agent =
+    <filter monitor_agent>
+      @type record_transformer
+      enable_ruby
+      <record>
+        source namespace:${ENV['MY_NAMESPACE']}/pod:${ENV['MY_POD_NAME']}
+        sourcetype "fluentd:monitor-agent"
+        {{- with or .Values.kubernetes.clusterName .Values.global.kubernetes.clusterName | default "cluster_name" }}
+        cluster_name {{ . }}
+        {{- end }}
+        {{- with or .Values.global.monitoring_agent_index_name .Values.global.splunk.hec.indexName | default "main" }}
+        splunk_index {{ . }}
+        {{- end }}
+        {{- if .Values.customMetadata }}
+        {{- range .Values.customMetadata }}
+        {{ .name }} "{{ .value }}"
+        {{- end }}
+        {{- end }}
+      </record>
+    </filter>
+    {{- end }}
+
     <filter kube.**>
       @type record_modifier
       <record>
@@ -125,3 +157,52 @@ data:
       </buffer>
       {{- end }}
     </match>
+    {{- if .Values.global.monitoring_agent_enabled }}
+    <match monitor_agent>
+      @type splunk_hec
+      protocol {{ or .Values.splunk.hec.protocol .Values.global.splunk.hec.protocol }}
+      {{- with or .Values.splunk.hec.host .Values.global.splunk.hec.host }}
+      hec_host {{ . | quote }}
+      {{- end }}
+      {{- with or .Values.splunk.hec.port .Values.global.splunk.hec.port }}
+      hec_port {{ . }}
+      {{- end }}
+      hec_token "#{ENV['SPLUNK_HEC_TOKEN']}"
+      host "#{ENV['NODE_NAME']}"
+      index_key splunk_index
+      source_key source
+      sourcetype_key sourcetype
+      <fields>
+        {{- if or .Values.kubernetes.clusterName .Values.global.kubernetes.clusterName }}
+        cluster_name
+        {{- end }}
+        {{- if .Values.customMetadata }}
+        {{- range .Values.customMetadata }}
+        {{ .name }}
+        {{- end }}
+        {{- end }}
+      </fields>
+      insecure_ssl {{ or .Values.splunk.hec.insecureSSL .Values.global.splunk.hec.insecureSSL | default false }}
+      {{- if or .Values.splunk.hec.clientCert .Values.global.splunk.hec.clientCert }}
+      client_cert /fluentd/etc/splunk/hec_client_cert
+      {{- end }}
+      {{- if  or .Values.splunk.hec.clientKey .Values.global.splunk.hec.clientKey }}
+      client_key /fluentd/etc/splunk/hec_client_key
+      {{- end }}
+      {{- if or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile }}
+      ca_file /fluentd/etc/splunk/hec_ca_file
+      {{- end }}
+      app_name {{ .Chart.Name }}
+      app_version {{ .Chart.Version }}
+      {{- with .Values.buffer }}
+      <buffer>
+      {{- range $parameter, $value := . }}
+        {{ $parameter }} {{ $value }}
+      {{- end }}
+      </buffer>
+      {{- end }}
+      <format>
+        @type json
+      </format>
+    </match>
+    {{- end }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/configMapMetricsAggregator.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/configMapMetricsAggregator.yaml
@@ -26,6 +26,35 @@ data:
       interval {{ . }}
       {{- end }}
     </source>
+    <source>
+      @id fluentd-monitor-agent
+      @type monitor_agent
+      {{- if .Values.global.monitoring_agent_enabled }}
+      tag monitor_agent
+      {{- end }}
+    </source>
+    {{- if .Values.global.monitoring_agent_enabled }}
+    # = filters for monitor agent =
+    <filter monitor_agent>
+      @type record_transformer
+      enable_ruby
+      <record>
+        source namespace:${ENV['MY_NAMESPACE']}/pod:${ENV['MY_POD_NAME']}
+        sourcetype "fluentd:monitor-agent"
+        {{- with or .Values.kubernetes.clusterName .Values.global.kubernetes.clusterName | default "cluster_name" }}
+        cluster_name {{ . }}
+        {{- end }}
+        {{- with or .Values.global.monitoring_agent_index_name .Values.global.splunk.hec.indexName | default "main" }}
+        splunk_index {{ . }}
+        {{- end }}
+        {{- if .Values.customMetadata }}
+        {{- range .Values.customMetadata }}
+        {{ .name }} "{{ .value }}"
+        {{- end }}
+        {{- end }}
+      </record>
+    </filter>
+    {{- end }}
     <filter kube.**>
       @type record_modifier
       <record>
@@ -109,3 +138,52 @@ data:
       </buffer>
       {{- end }}
     </match>
+    {{- if .Values.global.monitoring_agent_enabled }}
+    <match monitor_agent>
+      @type splunk_hec
+      protocol {{ or .Values.splunk.hec.protocol .Values.global.splunk.hec.protocol }}
+      {{- with or .Values.splunk.hec.host .Values.global.splunk.hec.host }}
+      hec_host {{ . | quote }}
+      {{- end }}
+      {{- with or .Values.splunk.hec.port .Values.global.splunk.hec.port }}
+      hec_port {{ . }}
+      {{- end }}
+      hec_token "#{ENV['SPLUNK_HEC_TOKEN']}"
+      host "#{ENV['NODE_NAME']}"
+      index_key splunk_index
+      source_key source
+      sourcetype_key sourcetype
+      <fields>
+        {{- if or .Values.kubernetes.clusterName .Values.global.kubernetes.clusterName }}
+        cluster_name
+        {{- end }}
+        {{- if .Values.customMetadata }}
+        {{- range .Values.customMetadata }}
+        {{ .name }}
+        {{- end }}
+        {{- end }}
+      </fields>
+      insecure_ssl {{ or .Values.splunk.hec.insecureSSL .Values.global.splunk.hec.insecureSSL | default false }}
+      {{- if or .Values.splunk.hec.clientCert .Values.global.splunk.hec.clientCert }}
+      client_cert /fluentd/etc/splunk/hec_client_cert
+      {{- end }}
+      {{- if  or .Values.splunk.hec.clientKey .Values.global.splunk.hec.clientKey }}
+      client_key /fluentd/etc/splunk/hec_client_key
+      {{- end }}
+      {{- if or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile }}
+      ca_file /fluentd/etc/splunk/hec_ca_file
+      {{- end }}
+      app_name {{ .Chart.Name }}
+      app_version {{ .Chart.Version }}
+      {{- with .Values.buffer }}
+      <buffer>
+      {{- range $parameter, $value := . }}
+        {{ $parameter }} {{ $value }}
+      {{- end }}
+      </buffer>
+      {{- end }}
+      <format>
+        @type json
+      </format>
+    </match>
+    {{- end }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
@@ -61,6 +61,14 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: MY_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           - name: SPLUNK_HEC_TOKEN
             valueFrom:
               secretKeyRef:
@@ -83,6 +91,18 @@ spec:
           - name: secrets
             mountPath: /fluentd/etc/splunk
             readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /api/plugins.json
+            port: 24220
+          initialDelaySeconds: 60
+          periodSeconds: 60
+        {{- if .Values.global.monitoring_agent_enabled }}
+        ports:
+        - containerPort: 24220
+          name: monitor-agent
+          protocol: TCP
+        {{- end }}
       volumes:
       - name: conf-configmap
         configMap:

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
@@ -58,6 +58,14 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
+          - name: MY_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
           {{- if or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile }}
           - name: SSL_CERT_FILE
             value: /fluentd/etc/splunk/hec_ca_file
@@ -75,6 +83,18 @@ spec:
           - name: secrets
             mountPath: /fluentd/etc/splunk
             readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /api/plugins.json
+            port: 24220
+          initialDelaySeconds: 60
+          periodSeconds: 60
+        {{- if .Values.global.monitoring_agent_enabled }}
+        ports:
+        - containerPort: 24220
+          name: monitor-agent
+          protocol: TCP
+        {{- end }}
       volumes:
       - name: conf-configmap
         configMap:

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
@@ -257,4 +257,5 @@ global:
   kubernetes:
     clusterName: "cluster_name"
   prometheus_enabled: true
-  monitoring_agent_enabled: true
+  monitoring_agent_enabled: false
+  monitoring_agent_index_name: false

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/configMap.yaml
@@ -76,6 +76,22 @@ data:
     {{- end }}
     {{- end }}
 
+    <source>
+      @id fluentd-monitor-agent
+      @type monitor_agent
+      {{- if .Values.global.monitoring_agent_enabled }}
+      tag monitor_agent
+      {{- end }}
+    </source>
+
+    {{- if .Values.global.monitoring_agent_enabled }}
+    # = filters for monitor agent =
+    <filter monitor_agent>
+      @type jq_transformer
+      jq ".record.source = \"namespace:#{ENV['MY_NAMESPACE']}/pod:#{ENV['MY_POD_NAME']}\" | .record.sourcetype = \"fluentd:monitor-agent\" | .record.cluster_name = \"{{ or .Values.kubernetes.clusterName .Values.global.kubernetes.clusterName | default "cluster_name" }}\" | .record.splunk_index = \"{{ or .Values.global.monitoring_agent_index_name .Values.global.splunk.hec.indexName .Values.splunk.hec.indexName | default "main" }}\" {{- if .Values.customMetadata }}{{- range .Values.customMetadata }}| .record.{{ .name }} = \"{{ .value }}\" {{- end }}{{- end }} | .record"
+    </filter>
+    {{- end }}
+
     <filter kube.**>
       @type jq_transformer
       # in ruby '\\' will escape and become just '\', since we need two '\' in the `gsub` jq filter, it becomes '\\\\'.
@@ -99,7 +115,7 @@ data:
     {{- end }}
     {{- end }}
 
-    <match kube.**>
+    <match **>
       @type splunk_hec
       protocol {{ or .Values.splunk.hec.protocol .Values.global.splunk.hec.protocol | default "https" }}
       {{- with or .Values.splunk.hec.host .Values.global.splunk.hec.host }}
@@ -145,5 +161,10 @@ data:
         {{ $parameter }} {{ $value }}
       {{- end }}
       </buffer>
+      {{- end }}
+      {{- if .Values.global.monitoring_agent_enabled }}
+      <format monitor_agent>
+        @type json
+      </format>
       {{- end }}
     </match>

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/deployment.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/deployment.yaml
@@ -89,6 +89,18 @@ spec:
         - name: secrets
           mountPath: /fluentd/etc/splunk
           readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /api/plugins.json
+            port: 24220
+          initialDelaySeconds: 60
+          periodSeconds: 60
+        {{- if .Values.global.monitoring_agent_enabled }}
+        ports:
+        - containerPort: 24220
+          name: monitor-agent
+          protocol: TCP
+        {{- end }}
       volumes:
       - name: conf-configmap
         configMap:

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
@@ -307,4 +307,5 @@ global:
   kubernetes:
     clusterName: "cluster_name"
   prometheus_enabled: true
-  monitoring_agent_enabled: true
+  monitoring_agent_enabled: false
+  monitoring_agent_index_name: false

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -44,6 +44,7 @@ global:
     clusterName: "cluster_name"
   prometheus_enabled:
   monitoring_agent_enabled:
+  monitoring_agent_index_name:
   # deploy a ServiceMonitor object for usage of the PrometheusOperator
   serviceMonitor:
     enabled: false

--- a/test/test_setup.yaml
+++ b/test/test_setup.yaml
@@ -41,9 +41,7 @@ spec:
     spec:
       containers:
       - name: pod-w-index-w-ns-index
-        image: rock1017/log-generator:latest
-        args:
-          - "1"
+        image: rock1017/log-generator:2.2.6
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -64,9 +62,7 @@ spec:
     spec:
       containers:
       - name: pod-wo-index-w-ns-index
-        image: rock1017/log-generator:latest
-        args:
-          - "1"
+        image: rock1017/log-generator:2.2.6
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -88,9 +84,7 @@ spec:
     spec:
       containers:
       - name: pod-w-index-wo-ns-index
-        image: rock1017/log-generator:latest
-        args:
-          - "1"
+        image: rock1017/log-generator:2.2.6
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -111,9 +105,7 @@ spec:
     spec:
       containers:
       - name: pod-w-index-w-ns-exclude
-        image: rock1017/log-generator:latest
-        args:
-          - "1"
+        image: rock1017/log-generator:2.2.6
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -134,9 +126,7 @@ spec:
     spec:
       containers:
       - name: pod-w-index-w-ns-exclude
-        image: rock1017/log-generator:latest
-        args:
-          - "1"
+        image: rock1017/log-generator:2.2.6
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -155,6 +145,4 @@ spec:
     spec:
       containers:
       - name: pod-wo-index-wo-ns-index
-        image: rock1017/log-generator:latest
-        args:
-          - "1"
+        image: rock1017/log-generator:2.2.6


### PR DESCRIPTION
Adding monitor agent for all pods for polling. https://github.com/splunk/splunk-connect-for-kubernetes/issues/609
can be configured to send it to index set in `Values.global.monitoring_agent_index_name` 
Adding liveness probes per request https://github.com/splunk/splunk-connect-for-kubernetes/issues/626