### PR TITLE
Add support for a regular ClusterIP service

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/service-headless.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/service-headless.yaml
@@ -1,8 +1,12 @@
-{{- if .Values.global.serviceMonitor.enabled }}
+{{- if .Values.global.metrics.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
+  {{- if .Values.global.metrics.service.headless }}
   name: {{ template "splunk-kubernetes-logging.fullname" . }}-headless
+  {{- else }}
+  name: {{ template "splunk-kubernetes-logging.fullname" . }}
+  {{- end }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "splunk-kubernetes-logging.name" . }}
@@ -10,7 +14,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  type: ClusterIP
+  {{- if not .Values.global.metrics.service.headless }}
   clusterIP: None
+  {{- end }}
   ports:
     - port: {{ .Values.global.serviceMonitor.metricsPort }}
       protocol: TCP

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -476,6 +476,10 @@ global:
   prometheus_enabled: true
   monitoring_agent_enabled: true
   monitoring_agent_index_name:
+  metrics:
+    service:
+      enabled: true
+      headless: true
   # deploy a ServiceMonitor object for usage of the PrometheusOperator
   serviceMonitor:
     enabled: false

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -45,6 +45,10 @@ global:
   prometheus_enabled:
   monitoring_agent_enabled:
   monitoring_agent_index_name:
+  metrics:
+    service:
+      enabled: true
+      headless: true
   # deploy a ServiceMonitor object for usage of the PrometheusOperator
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
## Proposed changes

This is an adjustment to https://github.com/splunk/splunk-connect-for-kubernetes/pull/288. ClusterIP is needed in some scenarios for metrics ingestion (I need it for use with [signalfx](https://docs.signalfx.com/en/latest/integrations/agent/monitors/prometheus-exporter.html)). This enables you to control whether the service created for metrics is headless or not and allows you to have a service without a ServiceMonitor. Headless defaults to true to preserve existing behavior as default.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

