### PR TITLE
Include priorityClassName for the metrics aggregator deployment/pod

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
@@ -102,3 +102,7 @@ spec:
       - name: secrets
         secret:
           secretName: {{ template "splunk-kubernetes-metrics.secret" . }}
+      {{- if .Values.priorityClassNameAgg }}
+      priorityClassName: {{ .Values.priorityClassNameAgg }}
+      {{- end }}
+

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
@@ -171,8 +171,11 @@ tolerations:
 # blank by default.
 aggregatorTolerations: {}
 
-# Defines priorityClassName to assign a priority class to pods.
-priorityClassName:
+# Defines priorityClassName to assign a priority class to metrics (daemonset) pods.
+priorityClassName: 
+
+# Defines priorityClassName to assign a priority class to metrics aggregetor (deployment) pods.
+priorityClassNameAgg: 
 
 # Defines node affinity to restrict pod deployment.
 affinity: {}

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -984,8 +984,12 @@ splunk-kubernetes-metrics:
   # blank by default.
   aggregatorTolerations: {}
 
-  # Defines priorityClassName to assign a priority class to pods.
-  priorityClassName:
+  # Defines priorityClassName to assign a priority class to metrics (daemonset) pods.
+  priorityClassName: 
+
+  # Defines priorityClassName to assign a priority class to metrics aggregetor (deployment) pods.
+  priorityClassNameAgg: 
+
 
   # Defines node affinity to restrict pod deployment.
   affinity: {}


### PR DESCRIPTION
## Proposed changes

Adds the ability to set a `priorityClassName` on the metrics aggregator pod, so it can be prioritised above (or below) other pods.

All the other pods in this chart have the ability to set this - see #637 and #172. Only the metrics aggregator is missing.

I've added a new `priorityClassNameAgg` value rather than reusing the existing `priorityClassName`, because daemonset pods typically need a higher priority than the deployment pods.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

