### PR TITLE
Updated filter regex which remove empty lines

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -244,7 +244,7 @@ data:
         @type grep
         <exclude>
          key log
-         pattern ^$
+         pattern \A\z
         </exclude>
       </filter>
       # Enrich log with k8s metadata


### PR DESCRIPTION
In ruby, `^` points to starting of a line and `$` points to ending of line irrespective of multiline option.
If a multiline log message contains an empty line, ^$ matches the string and the f]grep filter drops the event.

To overcome this issue, use `\A` which points to the start of the string and `\z` which points to the end of the string