### PR TITLE
metrics subchart should use helm naming convention

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
@@ -46,7 +46,7 @@ spec:
       {{- end }}
       {{- if .Values.image.usePullSecret }}
       imagePullSecrets:
-      - name: {{ .Values.image.pullsecretName}}
+      - name: {{ .Values.image.pullSecretName}}
       {{- end }}
       containers:
       - name: splunk-fluentd-k8s-metrics

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
@@ -42,7 +42,7 @@ spec:
       {{- end }}
       {{- if .Values.imageAgg.usePullSecret }}
       imagePullSecrets:
-      - name: {{ .Values.imageAgg.pullsecretName}}
+      - name: {{ .Values.imageAgg.pullSecretName}}
       {{- end }}
       containers:
       - name: splunk-fluentd-k8s-metrics-agg

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
@@ -88,7 +88,7 @@ image:
   # Indicates if the image should be pulled using authentication from a secret
   usePullSecret: false
   # The name of the pull secret to attach to the respective serviceaccount used to pull the image
-  pullsecretName:
+  pullSecretName:
 
 # Defines which version of image to use, and how it should be pulled.
 imageAgg:
@@ -103,7 +103,7 @@ imageAgg:
   # Indicates if the image should be pulled using authentication from a secret
   usePullSecret: false
   # The name of the pull secret to attach to the respective serviceaccount used to pull the image
-  pullsecretName:
+  pullSecretName:
 
 # Environment variable for metrics daemonset
 environmentVar:

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -905,7 +905,7 @@ splunk-kubernetes-metrics:
     # Indicates if the image should be pulled using authentication from a secret
     usePullSecret: false
     # The name of the pull secret to attach to the respective serviceaccount used to pull the image
-    pullsecretName:
+    pullSecretName:
 
   # Defines which version of image to use, and how it should be pulled.
   imageAgg:
@@ -920,7 +920,7 @@ splunk-kubernetes-metrics:
     # Indicates if the image should be pulled using authentication from a secret
     usePullSecret: false
     # The name of the pull secret to attach to the respective serviceaccount used to pull the image
-    pullsecretName:
+    pullSecretName:
 
   # Environment variable for metrics daemonset
   environmentVar:


### PR DESCRIPTION
## Proposed changes

This PR changes the capitalization of the `pullsecretName` values in the `splunk-kubernetes-metrics` subchart to be consistent with the other subcharts and to conform to standard [Helm naming convention](https://helm.sh/docs/chart_best_practices/values/#naming-conventions).

My hope is that this saves users some time and confusion when using the Helm chart.

closes #676

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

This shouldn't break anything in the app, but the value key would need to be changed to upgrade existing releases that make use of pull secrets.

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

