### PR TITLE
Add possibility to send logs from different containers to different indexes from one pod in k8s

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -274,7 +274,7 @@ data:
           cluster_name {{ . }}
           {{- end }}
           # set the splunk_index field to the value found in the pod splunk.com/index annotations. if not set, use namespace annotation, or default to the default_index
-          splunk_index ${record.dig("kubernetes", "annotations", "splunk.com/index") ? record.dig("kubernetes", "annotations", "splunk.com/index") : record.dig("kubernetes", "namespace_annotations", "splunk.com/index") ? (record["kubernetes"]["namespace_annotations"]["splunk.com/index"]) : ("{{ or .Values.splunk.hec.indexName .Values.global.splunk.hec.indexName | default "main"}}")}
+          splunk_index ${record.dig("kubernetes", "annotations", "splunk.com/index."+record.dig("kubernetes","container_name")) ? record.dig("kubernetes", "annotations", "splunk.com/index."+record.dig("kubernetes","container_name")) : record.dig("kubernetes", "annotations", "splunk.com/index") ? record.dig("kubernetes", "annotations", "splunk.com/index") : record.dig("kubernetes", "namespace_annotations", "splunk.com/index") ? (record["kubernetes"]["namespace_annotations"]["splunk.com/index"]) : ("{{ or .Values.splunk.hec.indexName .Values.global.splunk.hec.indexName | default "main"}}")}
           {{- range .Values.k8sMetadata.podLabels }}
           label_{{ . }} ${record.dig("kubernetes","labels","{{ . }}")}
           {{- end }}


### PR DESCRIPTION
## Proposed changes

There was no possibilities to send logs from different containers within one pod in k8s cluster to different splunk's indexes. I added the possibility in the change, it is enough to add annotations similar to : 
splunk.com/index.CONTAINER_NAME: index

For example
splunk.com/index.httpbin: index1
splunk.com/index.istio-proxy: index2

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [ x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [ x] I have added necessary documentation (if appropriate)
- [ x] Any dependent changes have been merged and published in downstream modules

