### PR TITLE
Remove hec token from splunk logs

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -183,6 +183,14 @@ data:
   output.conf: |-
     #Events are emitted to the CONCAT label from the container, file and journald sources for multiline processing.
     <label @CONCAT>
+    # Remove HEC token from log
+      <filter tail.containers.var.log.containers.{{ .Release.Name }}-*.log>
+        @type grep
+        <exclude>
+         key log
+         pattern /hec_token \"[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}\"/
+        </exclude>
+      </filter>
       {{- if .Values.charEncodingUtf8 }}
       # = set strings to uft-8 encoding =
       <filter **>

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -188,7 +188,7 @@ data:
         @type grep
         <exclude>
          key log
-         pattern /hec_token \"[\w]{8}-[\w]{4}-[\w]{4}-[\w]{4}-[\w]{12}\"/
+         pattern /hec_token \"[\w-]+\"/
         </exclude>
       </filter>
       {{- if .Values.charEncodingUtf8 }}


### PR DESCRIPTION
Fixing https://github.com/splunk/splunk-connect-for-kubernetes/issues/601

- HEC token were getting ingested in Splunk logs  
- Added filter to exclude logs having hec token