### PR TITLE
Add labels to differentiate splunk-kubernetes-metrics deployment and daemon set pods

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: {{ template "splunk-kubernetes-metrics.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    component: collector
     engine: fluentd
 spec:
   updateStrategy:
@@ -23,6 +24,7 @@ spec:
         chart: {{ template "splunk-kubernetes-metrics.chart" . }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
+        component: collector
         engine: fluentd
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       labels:
         app: {{ template "splunk-kubernetes-metrics.name" . }}
+        chart: {{ template "splunk-kubernetes-metrics.chart" . }}
         release: {{ .Release.Name }}
         component: aggregator
       annotations:

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
@@ -7,6 +7,7 @@ metadata:
     chart: {{ template "splunk-kubernetes-metrics.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    component: aggregator
 spec:
   strategy:
     type: RollingUpdate
@@ -20,6 +21,7 @@ spec:
       labels:
         app: {{ template "splunk-kubernetes-metrics.name" . }}
         release: {{ .Release.Name }}
+        component: aggregator
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         checksum/config: {{ include (print $.Template.BasePath "/configMapMetricsAggregator.yaml") . | sha256sum }}


### PR DESCRIPTION
## Proposed changes

Resolves issue (#652). This change adds additional labels to the metrics aggregator daemon set and deployment to allow for querying pods by the respective types: aggregator and collector. When using tools like [k9s](https://k9scli.io/) it is unable to differentiate the difference between the aggregator (deployment) and collector (daemon set) pods because all of the labels are the same.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

