### PR TITLE
move customFilters to it's own label to prevent deadlocks

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -75,7 +75,7 @@ data:
     <source>
       @id containers.log
       @type tail
-      @label @CONCAT
+      @label @CUSTOM
       tag tail.containers.*
       path {{ .Values.fluentd.path | default "/var/log/containers/*.log" }}
       {{- if .Values.fluentd.exclude_path }}
@@ -109,7 +109,7 @@ data:
     <source>
       @id tail.file.{{ $name }}
       @type tail
-      @label @CONCAT
+      @label @CUSTOM
       tag tail.file.{{ or $logDef.sourcetype $name }}
       path {{ $logDef.from.file.path }}
       pos_file {{ $.Values.containers.path }}/splunk-fluentd-{{ $name }}.pos
@@ -152,7 +152,7 @@ data:
     <source>
       @id journald-{{ $name }}
       @type systemd
-      @label @CONCAT
+      @label @CUSTOM
       tag journald.{{ or $logDef.sourcetype $name }}
       path {{ $.Values.journalLogPath | quote }}
       matches [{ "_SYSTEMD_UNIT": {{ $logDef.from.journald.unit | quote }} }]
@@ -460,9 +460,9 @@ data:
       {{- end }}
       {{- end }}
 
-      # Events are relabeled then emitted to the SPLUNK label
+      # Events are relabeled then emitted to the CONCAT label
       <match **>
         @type relabel
-        @label @SPLUNK
+        @label @CONCAT
       </match>
     </label>

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -330,17 +330,6 @@ data:
         jq ".record.source = \"namespace:#{ENV['MY_NAMESPACE']}/pod:#{ENV['MY_POD_NAME']}\" | .record.sourcetype = \"fluentd:monitor-agent\" | .record.cluster_name = \"{{ or .Values.kubernetes.clusterName .Values.global.kubernetes.clusterName | default "cluster_name" }}\" | .record.splunk_index = \"{{ or .Values.global.monitoring_agent_index_name .Values.global.splunk.hec.indexName .Values.splunk.hec.indexName | default "main" }}\" {{- if .Values.customMetadata }}{{- range .Values.customMetadata }}| .record.{{ .name }} = \"{{ .value }}\" {{- end }}{{- end }} | .record"
       </filter>
       {{- end }}
-      # = custom filters specified by users =
-      {{- range $name, $filterDef := .Values.customFilters }}
-      {{- if and $filterDef.tag $filterDef.type }}
-      <filter {{ $filterDef.tag }}>
-        @type {{ $filterDef.type }}
-        {{- with $filterDef.body }}
-        {{ . | nindent 8 }}
-        {{- end }}
-      </filter>
-      {{- end }}
-      {{- end }}
 
       # = output =
       <match **>
@@ -456,5 +445,24 @@ data:
           add_newline false
         </format>
         {{- end }}
+      </match>
+    </label>
+    # = custom filters specified by users =
+    <label @CUSTOM>
+      {{- range $name, $filterDef := .Values.customFilters }}
+      {{- if and $filterDef.tag $filterDef.type }}
+      <filter {{ $filterDef.tag }}>
+        @type {{ $filterDef.type }}
+        {{- with $filterDef.body }}
+        {{ . | nindent 8 }}
+        {{- end }}
+      </filter>
+      {{- end }}
+      {{- end }}
+
+      # Events are relabeled then emitted to the SPLUNK label
+      <match **>
+        @type relabel
+        @label @SPLUNK
       </match>
     </label>


### PR DESCRIPTION
## Proposed changes

Move customFilters to a new CUSTOM label to prevent deadlocks when using the concat plugin.  The example multiline configuration will cause deadlocks when timeouts (flush interval) is hit because the customFilters are in the SPLUNK label and the timeout_label will cause it to loop back around to hit the SPLUNK label again.  You also can't use the CONCAT label because it relabels to SPLUNK.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

