### PR TITLE
Fix log duplication when using wildcards in log path

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -114,6 +114,9 @@ data:
       path {{ $logDef.from.file.path }}
       pos_file {{ $.Values.containers.path }}/splunk-fluentd-{{ $name }}.pos
       read_from_head true
+      {{- if contains "*" $logDef.from.file.path }}
+      follow_inodes true
+      {{- end }}
       path_key source
       {{- if $logDef.multiline }}
       multiline_flush_interval {{ $logDef.multiline.flushInterval | default "5s" }}


### PR DESCRIPTION
## Proposed changes

Automatically add `follow_inodes true` Fluentd parameter if path contains wildcards.
From fluentd [documentation](https://docs.fluentd.org/input/tail#follow_inodes):
> You should set true when you use * or strftime format in path.

Resolves: #728

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

