### PR TITLE
Add support for explicit update strategy

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/daemonset.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/daemonset.yaml
@@ -9,8 +9,10 @@ metadata:
     heritage: {{ .Release.Service }}
     engine: fluentd
 spec:
+{{- with .Values.updateStrategy }}
   updateStrategy:
-    type: RollingUpdate
+    {{- toYaml . | nindent 4 }}
+{{- end }}
   selector:
     matchLabels:
       app: {{ template "splunk-kubernetes-logging.name" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -145,6 +145,11 @@ podSecurityPolicy:
   # set to false if AppArmor is not available
   apparmor_security: true
 
+# Set the daemonset's update strategy
+updateStrategy:
+  type: RollingUpdate
+  maxUnavailable: "100%"
+
 # Create or use existing secret if name is empty default name is used
 secret:
   create: true

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
@@ -10,8 +10,10 @@ metadata:
     component: collector
     engine: fluentd
 spec:
+{{- with .Values.updateStrategy }}
   updateStrategy:
-    type: RollingUpdate
+    {{- toYaml . | nindent 4 }}
+{{- end }}
   selector:
     matchLabels:
       name: {{ template "splunk-kubernetes-metrics.fullname" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
@@ -41,6 +41,11 @@ podSecurityPolicy:
   # set to false if AppArmor is not available
   apparmor_security: true
 
+# Set the daemonset's update strategy
+updateStrategy:
+  type: RollingUpdate
+  maxUnavailable: "100%"
+
 # = Splunk HEC Connection =
 splunk:
   # Configurations for HEC (HTTP Event Collector)

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/deployment.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/deployment.yaml
@@ -8,8 +8,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  strategy:
-    type: RollingUpdate
+{{- with .Values.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
   selector:
     matchLabels:
       app: {{ template "splunk-kubernetes-objects.name" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
@@ -43,6 +43,11 @@ podSecurityPolicy:
   # set to false if AppArmor is not available
   apparmor_security: true
 
+# Set the daemonset's update strategy
+updateStrategy:
+  type: RollingUpdate
+  maxUnavailable: "100%"
+
 # Defines priorityClassName to assign a priority class to pods.
 priorityClassName:
 


### PR DESCRIPTION
## Proposed changes
Adds support for explicitly specifying the updateStrategy.  Some clusters are quite large and a rolling update for a daemonset can take a considerable amount of time (often times this can also cause the `helm upgrade` command to fail if it passes the default timeout value).  Since we don't much care about `maxUnavailable` for a daemonset, setting this to 100% ensures a quick helm update will occur before timeouts are reached.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

