### PR TITLE
Allow custom labels on daemonset/deployment/pods

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/daemonset.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/daemonset.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     engine: fluentd
+    {{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+    {{- end }}
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -20,6 +23,9 @@ spec:
       labels:
         app: {{ template "splunk-kubernetes-logging.name" . }}
         release: {{ .Release.Name }}
+        {{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
         {{- if .Values.global.prometheus_enabled }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -327,6 +327,9 @@ environmentVar:
 # Pod annotations for daemonset
 podAnnotations:
 
+# Extra labels for daemonset, pods
+extraLabels:
+
 # Controls the resources used by the fluentd daemonset
 resources:
   # limits:

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
@@ -9,6 +9,9 @@ metadata:
     heritage: {{ .Release.Service }}
     component: collector
     engine: fluentd
+    {{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+    {{- end }}
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -27,6 +30,9 @@ spec:
         heritage: {{ .Release.Service }}
         component: collector
         engine: fluentd
+        {{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 8 }}
+        {{- end }}
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
@@ -8,6 +8,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: aggregator
+    {{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+    {{- end }}
 spec:
   strategy:
     type: RollingUpdate
@@ -24,6 +27,9 @@ spec:
         chart: {{ template "splunk-kubernetes-metrics.chart" . }}
         release: {{ .Release.Name }}
         component: aggregator
+        {{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 8 }}
+        {{- end }}
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         checksum/config: {{ include (print $.Template.BasePath "/configMapMetricsAggregator.yaml") . | sha256sum }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
@@ -8,8 +8,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: aggregator
-    {{- if .Values.extraLabels }}
-{{ toYaml .Values.extraLabels | indent 4 }}
+    {{- if .Values.extraLabelsAgg }}
+{{ toYaml .Values.extraLabelsAgg | indent 4 }}
     {{- end }}
 spec:
   strategy:
@@ -27,8 +27,8 @@ spec:
         chart: {{ template "splunk-kubernetes-metrics.chart" . }}
         release: {{ .Release.Name }}
         component: aggregator
-        {{- if .Values.extraLabels }}
-{{ toYaml .Values.extraLabels | indent 8 }}
+        {{- if .Values.extraLabelsAgg }}
+{{ toYaml .Values.extraLabelsAgg | indent 8 }}
         {{- end }}
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
@@ -127,8 +127,11 @@ podAnnotations:
 # Pod annotations for metrics aggregator pod
 podAnnotationsAgg: 
 
-# Extra labels for daemonset, pods
+# Extra labels for metrics daemonset, pods
 extraLabels:
+
+# Extra labels for metrics aggregator deployment, pods
+extraLabelsAgg:
 
 # Controls the resources used by the fluentd daemonset
 resources:

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
@@ -127,6 +127,9 @@ podAnnotations:
 # Pod annotations for metrics aggregator pod
 podAnnotationsAgg: 
 
+# Extra labels for daemonset, pods
+extraLabels:
+
 # Controls the resources used by the fluentd daemonset
 resources:
   fluent:

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/deployment.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "splunk-kubernetes-objects.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+    {{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 4 }}
+    {{- end }}
 spec:
   strategy:
     type: RollingUpdate
@@ -22,6 +25,9 @@ spec:
         app: {{ template "splunk-kubernetes-objects.name" . }}
         release: {{ .Release.Name }}
         engine: fluentd
+        {{- if .Values.extraLabels }}
+{{ toYaml .Values.extraLabels | indent 8 }}
+        {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configMap.yaml") . | sha256sum }}
         {{- if .Values.podAnnotations }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
@@ -214,6 +214,9 @@ environmentVar:
 # Pod annotations for object pod
 podAnnotations: 
 
+# Extra labels for object deployment, pods
+extraLabels:
+
 # = Resoruce Limitation Configs =
 resources:
   # limits:

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -977,8 +977,11 @@ splunk-kubernetes-metrics:
   # Pod annotations for metrics aggregator pod
   podAnnotationsAgg:
 
-  # Extra labels for daemonset, pods
+  # Extra labels for metrics aggregator daemonset, pods
   extraLabels:
+
+  # Extra labels for metrics aggregator deployment, pods
+  extraLabelsAgg:
 
   # Controls the resources used by the fluentd daemonset
   resources:

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -399,8 +399,11 @@ splunk-kubernetes-logging:
   # Environment variable for daemonset
   environmentVar:
 
-  # Pod annotations for object pod
+  # Pod annotations for logging pod
   podAnnotations:
+
+  # Extra labels for logging daemonset, pods
+  extraLabels:
 
   # Controls the resources used by the fluentd daemonset
   resources:
@@ -739,11 +742,14 @@ splunk-kubernetes-objects:
     # The name of the pull secret to attach to the respective serviceaccount used to pull the image
     pullSecretName:
 
-  # Environment variable for metrics daemonset
+  # Environment variable for objects daemonset
   environmentVar:
 
-  # Pod annotations for metrics daemonset
+  # Pod annotations for objects daemonset
   podAnnotations: 
+
+  # Extra labels for objects daemonset, pods
+  extraLabels:
 
   # = Resource Limitation Configs =
   resources:
@@ -969,7 +975,10 @@ splunk-kubernetes-metrics:
   podAnnotations: 
 
   # Pod annotations for metrics aggregator pod
-  podAnnotationsAgg: 
+  podAnnotationsAgg:
+
+  # Extra labels for daemonset, pods
+  extraLabels:
 
   # Controls the resources used by the fluentd daemonset
   resources:


### PR DESCRIPTION
## Proposed changes

This PR introduces a new variable to allow users to set their own custom labels on their deployments/daemonsets. 

Some organizations might have k8s admission controllers that require certain labels to be set, such as labels designating team/org ownership. This would enable such organizations to set the required labels.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [X] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [X] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

