### PR TITLE
Add "limit_recently_modified" parameter

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -114,6 +114,9 @@ data:
       path {{ $logDef.from.file.path }}
       pos_file {{ $.Values.containers.path }}/splunk-fluentd-{{ $name }}.pos
       read_from_head true
+      {{- if $logDef.limitRecentlyModified }}
+      limit_recently_modified {{ $logDef.limitRecentlyModified }}
+      {{- end }}
       path_key source
       {{- if $logDef.multiline }}
       multiline_flush_interval {{ $logDef.multiline.flushInterval | default "5s" }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -172,6 +172,7 @@ charEncodingUtf8: false
 #     firstline: "<regexp_to_detect_firstline_of_multiline>"
 #     flushInterval 5
 #   sourcetype: "<sourcetype_of_logs>"
+#   limitRecentlyModified: <time_duration>
 # ```
 #
 # = <source> =
@@ -222,6 +223,17 @@ charEncodingUtf8: false
 # = sourcetype =
 # sourcetype of each kind of log can be defined using the `sourcetype` field.
 # If `sourcetype` is not defined, `name` will be used.
+#
+# = limitRecentlyModified =
+# Limits the watching files that the modification time is within the specified time period when using * in path.
+# - <INTEGER>s: seconds
+# - <INTEGER>m: minutes
+# - <INTEGER>h: hours
+# - <INTEGER>d: days
+# - Otherwise, the field is parsed as float, and that float is the number of seconds
+# Example, specifying `limitRecentlyModified: 24h` will parse only files with modification time within 24 hours.
+# Files modified earlier will be skipped.
+# If `limitRecentlyModified` is not defined, this option will be disabled.
 #
 # ---
 # Here we have some default timestampExtraction and multiline settings for kubernetes components.

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -247,6 +247,7 @@ splunk-kubernetes-logging:
   #     firstline: "<regexp_to_detect_firstline_of_multiline>"
   #     flushInterval 5
   #   sourcetype: "<sourcetype_of_logs>"
+  #   limitRecentlyModified: <time_duration>
   # ```
   #
   # = <source> =
@@ -297,6 +298,17 @@ splunk-kubernetes-logging:
   # = sourcetype =
   # sourcetype of each kind of log can be defined using the `sourcetype` field.
   # If `sourcetype` is not defined, `name` will be used.
+  #
+  # = limitRecentlyModified =
+  # Limits the watching files that the modification time is within the specified time period when using * in path.
+  # - <INTEGER>s: seconds
+  # - <INTEGER>m: minutes
+  # - <INTEGER>h: hours
+  # - <INTEGER>d: days
+  # - Otherwise, the field is parsed as float, and that float is the number of seconds
+  # Example, specifying `limitRecentlyModified: 24h` will parse only files with modification time within 24 hours.
+  # Files modified earlier will be skipped.
+  # If `limitRecentlyModified` is not defined, this option will be disabled.
   #
   # ---
   # Here we have some default timestampExtraction and multiline settings for kubernetes components.


### PR DESCRIPTION
Changes:

- Add feature which allows skipping logs older than some specific time range

## Proposed changes

New functionality allows skipping files older than some specific time range. This allows avoiding duplicated logs with path which contain wildcards.
Parameter description in fluentd docs: https://docs.fluentd.org/input/tail#limit_recently_modified

## Types of changes

Changes only add new parameter. Without specifying this parameter, nothing changes in chart's behavior.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

