### PR TITLE
Allow RollingUpdate params to be configured

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/daemonset.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/daemonset.yaml
@@ -14,6 +14,10 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    {{- if .Values.rollingUpdate }}
+    rollingUpdate:
+{{ toYaml .Values.rollingUpdate | indent 6 }}
+    {{- end }}
   selector:
     matchLabels:
       app: {{ template "splunk-kubernetes-logging.name" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -78,7 +78,7 @@ splunk:
     # NOTE: The content of the certificate itself should be used here, not the file path.
     #       The certificate will be stored as a secret in kubernetes.
     #       Make sure you are providing the certificate as multiline string (use `|-`)
-    # Example: 
+    # Example:
     # caFile: |-
     #   -----BEGIN CERTIFICATE-----
     #   ...
@@ -93,7 +93,7 @@ splunk:
     #       The file will be stored as a secret in kubernetes.
     caFile:
     # Indicates if 4xx errors should consume chunk. If set to true, plugin will not retry sending chunk to splunk when 4xx error occurs. (Default: true)
-    consume_chunk_on_4xx_errors: 
+    consume_chunk_on_4xx_errors:
   # Configurations for Ingest API
   ingest_api:
     # serviceClientIdentifier is a string, the client identifier is used to make requests to the ingest API with authorization.
@@ -467,6 +467,22 @@ customFilters: {}
 # ```
 # WARNING: The fields being used here must be available inside the fluentd record.
 indexFields: []
+
+# Configure DaemonSet .spec.updateStrategy.rollingUpdate params if you want to speed up
+# rolling out a new version. By default only one pod after another is replaced when
+# upgrading.
+#
+# Example: replace 5 pods in parallel
+#
+# ```
+# rollingUpdate:
+#   maxUnavailable: 5
+# ```
+#
+# See https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
+# or `kubectl explain daemonset.spec.updateStrategy.rollingUpdate` for
+# documentation of available keys.
+rollingUpdate:
 
 # Global configurations
 # These configurations will be used if the corresponding local configurations are not set.

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
@@ -15,6 +15,10 @@ metadata:
 spec:
   updateStrategy:
     type: RollingUpdate
+    {{- if .Values.rollingUpdate }}
+    rollingUpdate:
+{{ toYaml .Values.rollingUpdate | indent 6 }}
+    {{- end }}
   selector:
     matchLabels:
       name: {{ template "splunk-kubernetes-metrics.fullname" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
@@ -63,7 +63,7 @@ splunk:
     # NOTE: The content of the certificate itself should be used here, not the file path.
     #       The certificate will be stored as a secret in kubernetes.
     #       Make sure you are providing the certificate as multiline string (use `|-`)
-    # Example: 
+    # Example:
     # caFile: |-
     #   -----BEGIN CERTIFICATE-----
     #   ...
@@ -78,7 +78,7 @@ splunk:
     #       The file will be stored as a secret in kubernetes.
     caFile:
     # Indicates if 4xx errors should consume chunk. If set to true, plugin will not retry sending chunk to splunk when 4xx error occurs. (Default: true)
-    consume_chunk_on_4xx_errors: 
+    consume_chunk_on_4xx_errors:
 
 # Create or use existing secret if name is empty default name is used
 secret:
@@ -122,10 +122,10 @@ environmentVar:
 environmentVarAgg:
 
 # Pod annotations for metrics daemonset
-podAnnotations: 
+podAnnotations:
 
 # Pod annotations for metrics aggregator pod
-podAnnotationsAgg: 
+podAnnotationsAgg:
 
 # Extra labels for metrics daemonset, pods
 extraLabels:
@@ -192,10 +192,10 @@ tolerations:
 aggregatorTolerations: {}
 
 # Defines priorityClassName to assign a priority class to metrics (daemonset) pods.
-priorityClassName: 
+priorityClassName:
 
 # Defines priorityClassName to assign a priority class to metrics aggregetor (deployment) pods.
-priorityClassNameAgg: 
+priorityClassNameAgg:
 
 # Defines node affinity to restrict pod deployment.
 affinity: {}
@@ -215,7 +215,7 @@ kubernetes:
   insecureSSL: false
   # Path to the CA file.
   #       Make sure you are providing the certificate as multiline string (use `|-`)
-  # Example: 
+  # Example:
   # caFile: |-
   #   -----BEGIN CERTIFICATE-----
   #   ...
@@ -295,8 +295,24 @@ customFilters: {}
   #     body: |
   #       <record>
   #         cluster_name "my_awesome_cluster"
-  #       </record>  
+  #       </record>
 customFiltersAggr: {}
+
+# Configure DaemonSet .spec.updateStrategy.rollingUpdate params if you want to speed up
+# rolling out a new version. By default only one pod after another is replaced when
+# upgrading.
+#
+# Example: replace 5 pods in parallel
+#
+# ```
+# rollingUpdate:
+#   maxUnavailable: 5
+# ```
+#
+# See https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
+# or `kubectl explain daemonset.spec.updateStrategy.rollingUpdate` for
+# documentation of available keys.
+rollingUpdate:
 
 # Global configurations
 # These configurations will be used if the corresponding local configurations are not set.

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -547,6 +547,22 @@ splunk-kubernetes-logging:
   # WARNING: The fields being used here must be available inside the fluentd record.
   indexFields: []
 
+  # Configure DaemonSet .spec.updateStrategy.rollingUpdate params if you want to speed up
+  # rolling out a new version. By default only one pod after another is replaced when
+  # upgrading.
+  #
+  # Example: replace 5 pods in parallel
+  #
+  # ```
+  # rollingUpdate:
+  #   maxUnavailable: 5
+  # ```
+  #
+  # See https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
+  # or `kubectl explain daemonset.spec.updateStrategy.rollingUpdate` for
+  # documentation of available keys.
+  rollingUpdate:
+
 ## Enabling splunk-kubernetes-objects will install the `splunk-kubernetes-objects` chart to a kubernetes
 ## cluster to collect kubernetes objects in the cluster to a Splunk indexer/indexer cluster.
 splunk-kubernetes-objects:
@@ -1164,3 +1180,19 @@ splunk-kubernetes-metrics:
   #         cluster_name "my_awesome_cluster"
   #       </record>
   customFiltersAggr: {}
+
+  # Configure DaemonSet .spec.updateStrategy.rollingUpdate params if you want to speed up
+  # rolling out a new version. By default only one pod after another is replaced when
+  # upgrading.
+  #
+  # Example: replace 5 pods in parallel
+  #
+  # ```
+  # rollingUpdate:
+  #   maxUnavailable: 5
+  # ```
+  #
+  # See https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
+  # or `kubectl explain daemonset.spec.updateStrategy.rollingUpdate` for
+  # documentation of available keys.
+  rollingUpdate:


### PR DESCRIPTION
## Proposed changes

Configure DaemonSet .spec.updateStrategy.rollingUpdate params if you want to speed up
rolling out a new version. By default only one pod after another is replaced when
upgrading.

Example: replace 5 pods in parallel

```
splunk-kubernetes-logging:
  rollingUpdate:
    maxUnavailable: 5
splunk-kubernetes-metrics:
  rollingUpdate:
    maxUnavailable: 5
```

See https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/
or `kubectl explain daemonset.spec.updateStrategy.rollingUpdate` for
documentation of available keys.

Closes #757

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

