### PR TITLE
separate nodeSelector for metrics-agg

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
@@ -38,7 +38,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "splunk-kubernetes-metrics.serviceAccountName" . }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.aggregatorNodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
       {{- end }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
@@ -191,6 +191,10 @@ tolerations:
 # blank by default.
 aggregatorTolerations: {}
 
+# Defines aggregator's nodeSelector. This may need to be different to metrics's daemonset.
+aggregatorNodeSelector:
+  beta.kubernetes.io/os: linux
+
 # Defines priorityClassName to assign a priority class to metrics (daemonset) pods.
 priorityClassName:
 

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -1063,6 +1063,10 @@ splunk-kubernetes-metrics:
   nodeSelector:
     beta.kubernetes.io/os: linux
 
+  # Defines which nodes should be selected to deploy the aggregator deployment
+  aggregatorNodeSelector:
+    beta.kubernetes.io/os: linux
+
   # This default tolerations allow the daemonset to be deployed on master nodes,
   # so that we can also collect metrics from those nodes.
   tolerations:


### PR DESCRIPTION
## Proposed changes

Existing implementation assumes that the metrics daemonset and the metrics-agg will requirement the same nodeSelector configuration.

However, this may not always be the case. For example, I want to keep management workloads on a set of management nodes. The metrics-agg deployment will count as a management workload. However, I still want to have the metrics daemonset running on all my nodes to collect metrics. With the current template this is not possible and the `.Values.nodeSelector` is common for both the metrics daemonset and the metrics-agg deployment.

This update implements a separate `aggregatorNodeSelector` value to make it distinct from the orignal `nodeSelector` value.

This fixes: https://github.com/splunk/splunk-connect-for-kubernetes/issues/776

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

