### PR TITLE
Document persistent journald log path /var/log/journal

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -41,7 +41,9 @@ containers:
   # Boolean if true, uses local time. UTC. Otherwise, UTC is used
   localTime: false
 
-# Directory where to read journald logs. (docker daemon logs, kubelet logs, and anyother specified serivce logs)
+# Directory where to read journald logs (docker daemon logs, kubelet logs, and anyother specified serivce logs).
+# Journald will use `/var/log/journal` automagically if the directory exists. For example on OpenShift this 
+# directory is used for persistent log storage.
 journalLogPath: /run/log/journal
 
 # Enriches pod log record with kubernetes data

--- a/helm-chart/splunk-connect-for-kubernetes/examples/openshift4-logging-only.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/examples/openshift4-logging-only.yaml
@@ -25,6 +25,7 @@ splunk-kubernetes-logging:
   containers:
     logFormatType: cri
     logFormat: "%Y-%m-%dT%H:%M:%S.%N%:z"
+  journalLogPath: /var/log/journal
   logs:
     # The `kube-audit` file has another path on OpenShift
     kube-audit:

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -226,7 +226,9 @@ splunk-kubernetes-logging:
     create: true
     name:
 
-  # Directory where to read journald logs.
+  # Directory where to read journald logs (docker daemon logs, kubelet logs, and anyother specified serivce logs).
+  # Journald will use `/var/log/journal` automagically if the directory exists. For example on OpenShift this 
+  # directory is used for persistent log storage.
   journalLogPath: /run/log/journal
 
   # Set to true, to change the encoding of all strings to utf-8.


### PR DESCRIPTION
## Proposed changes

On OpenShift by default the directory `/var/log/journal` exists
and journald will use this directory for persistent log storage.

See https://www.freedesktop.org/software/systemd/man/journald.conf.html#Storage=

Ref #779

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Documentation
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules