### PR TITLE
Use kubernetes.io/os label for node selector

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -383,7 +383,7 @@ tolerations:
 
 # Defines which nodes should be selected to deploy the fluentd daemonset.
 nodeSelector:
-  beta.kubernetes.io/os: linux
+  kubernetes.io/os: linux
 
 # Defines node affinity to restrict pod deployment.
 affinity: {}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
@@ -179,7 +179,7 @@ metricsInterval: 15s
 
 # Defines which nodes should be selected to deploy the fluentd daemonset.
 nodeSelector:
-  beta.kubernetes.io/os: linux
+  kubernetes.io/os: linux
 
 # This default tolerations allow the daemonset to be deployed on master nodes,
 # so that we can also collect metrics from those nodes.
@@ -193,7 +193,7 @@ aggregatorTolerations: {}
 
 # Defines aggregator's nodeSelector. This may need to be different to metrics's daemonset.
 aggregatorNodeSelector:
-  beta.kubernetes.io/os: linux
+  kubernetes.io/os: linux
 
 # Defines priorityClassName to assign a priority class to metrics (daemonset) pods.
 priorityClassName:

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
@@ -247,7 +247,7 @@ buffer:
 
 # Defines which nodes should be selected to deploy the fluentd daemonset.
 nodeSelector:
-  beta.kubernetes.io/os: linux
+  kubernetes.io/os: linux
 
 # This default tolerations allow the daemonset to be deployed on master nodes,
 # so that we can also collect metrics from those nodes.

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -462,7 +462,7 @@ splunk-kubernetes-logging:
 
   # Defines which nodes should be selected to deploy the fluentd daemonset.
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
 
   # Defines node affinity to restrict pod deployment.
   affinity: {}
@@ -815,7 +815,7 @@ splunk-kubernetes-objects:
 
   # Defines which nodes should be selected to deploy the fluentd daemonset.
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
 
   # This default tolerations allow the daemonset to be deployed on master nodes,
   # so that we can also collect metrics from those nodes.
@@ -1063,11 +1063,11 @@ splunk-kubernetes-metrics:
 
   # Defines which nodes should be selected to deploy the fluentd daemonset.
   nodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
 
   # Defines which nodes should be selected to deploy the aggregator deployment
   aggregatorNodeSelector:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
 
   # This default tolerations allow the daemonset to be deployed on master nodes,
   # so that we can also collect metrics from those nodes.

--- a/manifests/splunk-kubernetes-logging/daemonset.yaml
+++ b/manifests/splunk-kubernetes-logging/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       serviceAccountName: splunk-kubernetes-logging
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/manifests/splunk-kubernetes-metrics/daemonset.yaml
+++ b/manifests/splunk-kubernetes-metrics/daemonset.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       serviceAccountName: splunk-kubernetes-metrics
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/manifests/splunk-kubernetes-metrics/deploymentMetricsAggregator.yaml
+++ b/manifests/splunk-kubernetes-metrics/deploymentMetricsAggregator.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       serviceAccountName: splunk-kubernetes-metrics
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - name: splunk-fluentd-k8s-metrics-agg
         image: docker.io/splunk/k8s-metrics-aggr:1.1.12

--- a/manifests/splunk-kubernetes-objects/deployment.yaml
+++ b/manifests/splunk-kubernetes-objects/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: splunk-kubernetes-objects
       terminationGracePeriodSeconds: 30
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
       containers:
       - name: splunk-fluentd-k8s-objects
         image: docker.io/splunk/kube-objects:1.1.12


### PR DESCRIPTION
## Proposed changes

According warnig messages printed by K8s 1.22, the old label
`beta.kubernetes.io/os` is deprecated since 1.14.

Message printed by kubectl:

```
W0714 15:21:21.896079 2914669 warnings.go:70] spec.template.spec.nodeSelector[beta.kubernetes.io/os]: deprecated since v1.14; use "kubernetes.io/os" instead
```

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Not sure what type of change this is. :-)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

