### PR TITLE
Add support for configuring namespaces

### DIFF
--- a/ci_scripts/deploy_connector.sh
+++ b/ci_scripts/deploy_connector.sh
@@ -9,7 +9,7 @@ else
    helm delete $(helm ls --short)
 fi
 echo "Deploying k8s-connect with latest changes"
-helm install ci-sck --set global.splunk.hec.token=$CI_SPLUNK_HEC_TOKEN \
+helm install --create-namespace ci-sck --set global.splunk.hec.token=$CI_SPLUNK_HEC_TOKEN \
 --set global.splunk.hec.host=$CI_SPLUNK_HOST \
 --set kubelet.serviceMonitor.https=true \
 -f ci_scripts/sck_values.yml helm-artifacts/splunk-connect-for-kubernetes*.tgz

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/_helpers.tpl
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/_helpers.tpl
@@ -32,6 +32,17 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Get namespace to deploy to.
+*/}}
+{{- define "splunk-kubernetes-logging.namespace" -}}
+{{- if .Values.namespace -}}
+{{- .Values.namespace -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "splunk-kubernetes-logging.secret" -}}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-kubernetes-logging.fullname" . }}
+  namespace: {{ template "splunk-kubernetes-logging.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-logging.name" . }}
     chart: {{ template "splunk-kubernetes-logging.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/daemonset.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "splunk-kubernetes-logging.fullname" . }}
+  namespace: {{ template "splunk-kubernetes-logging.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-logging.name" . }}
     chart: {{ template "splunk-kubernetes-logging.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/podSecurityPolicy.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/podSecurityPolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "splunk-kubernetes-logging.fullname" . }}
+  namespace: {{ template "splunk-kubernetes-logging.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-logging.name" . }}
     chart: {{ template "splunk-kubernetes-logging.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/secret.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "splunk-kubernetes-logging.secret" . }}
+  namespace: {{ template "splunk-kubernetes-logging.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-logging.name" . }}
     chart: {{ template "splunk-kubernetes-logging.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/service-headless.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/service-headless.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- else }}
   name: {{ template "splunk-kubernetes-logging.fullname" . }}
   {{- end }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-kubernetes-logging.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-logging.name" . }}
     chart: {{ template "splunk-kubernetes-logging.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/serviceAccount.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/serviceAccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "splunk-kubernetes-logging.serviceAccountName" . }}
+  namespace: {{ template "splunk-kubernetes-logging.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-logging.name" . }}
     chart: {{ template "splunk-kubernetes-logging.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/serviceMonitor.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/serviceMonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "splunk-kubernetes-logging.fullname" . }}-headless
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ template "splunk-kubernetes-logging.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-logging.name" . }}
     chart: {{ template "splunk-kubernetes-logging.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -10,6 +10,9 @@
 # * error
 logLevel:
 
+# Namespace to deploy agent in (Optional: Will default to release namespace)
+namespace:
+
 # This is can be used to exclude verbose logs including various system and Helm/Tiller related logs.
 fluentd:
   # path of logfiles, default /var/log/containers/*.log

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/_helpers.tpl
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/_helpers.tpl
@@ -43,6 +43,17 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Get namespace to deploy to.
+*/}}
+{{- define "splunk-kubernetes-metrics.namespace" -}}
+{{- if .Values.namespace -}}
+{{- .Values.namespace -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "splunk-kubernetes-metrics.serviceAccountName" -}}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/configMap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-kubernetes-metrics.fullname" . }}
+  namespace: {{ template "splunk-kubernetes-metrics.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-metrics.name" . }}
     chart: {{ template "splunk-kubernetes-metrics.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/configMapMetricsAggregator.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/configMapMetricsAggregator.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-kubernetes-metrics.fullname" . }}-aggregator
+  namespace: {{ template "splunk-kubernetes-metrics.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-metrics.name" . }}
     chart: {{ template "splunk-kubernetes-metrics.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/daemonset.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "splunk-kubernetes-metrics.fullname" . }}
+  namespace: {{ template "splunk-kubernetes-metrics.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-metrics.name" . }}
     chart: {{ template "splunk-kubernetes-metrics.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "splunk-kubernetes-metrics.fullname" . }}-agg
+  namespace: {{ template "splunk-kubernetes-metrics.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-metrics.name" . }}
     chart: {{ template "splunk-kubernetes-metrics.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/podSecurityPolicy.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/podSecurityPolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "splunk-kubernetes-metrics.fullname" . }}
+  namespace: {{ template "splunk-kubernetes-metrics.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-metrics.name" . }}
     chart: {{ template "splunk-kubernetes-metrics.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/podSecurityPolicyAggregator.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/podSecurityPolicyAggregator.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "splunk-kubernetes-metrics.fullname" . }}-agg
+  namespace: {{ template "splunk-kubernetes-metrics.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-metrics.name" . }}
     chart: {{ template "splunk-kubernetes-metrics.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/secret.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "splunk-kubernetes-metrics.secret" . }}
+  namespace: {{ template "splunk-kubernetes-metrics.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-metrics.name" . }}
     chart: {{ template "splunk-kubernetes-metrics.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/serviceAccount.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/serviceAccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "splunk-kubernetes-metrics.serviceAccountName" . }}
+  namespace: {{ template "splunk-kubernetes-metrics.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-metrics.name" . }}
     chart: {{ template "splunk-kubernetes-metrics.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
@@ -11,6 +11,9 @@
 # Default value: "info"
 logLevel:
 
+# Namespace to deploy agent in (Optional: Will default to release namespace)
+namespace:
+
 rbac:
   # Specifies whether RBAC resources should be created.
   # This should be set to `false` if either:

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/_helpers.tpl
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/_helpers.tpl
@@ -32,6 +32,17 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Get namespace to deploy to.
+*/}}
+{{- define "splunk-kubernetes-objects.namespace" -}}
+{{- if .Values.namespace -}}
+{{- .Values.namespace -}}
+{{- else -}}
+{{- .Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "splunk-kubernetes-objects.serviceAccountName" -}}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/configMap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "splunk-kubernetes-objects.fullname" . }}
+  namespace: {{ template "splunk-kubernetes-objects.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-objects.name" . }}
     chart: {{ template "splunk-kubernetes-objects.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/deployment.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "splunk-kubernetes-objects.fullname" . }}
+  namespace: {{ template "splunk-kubernetes-objects.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-objects.name" . }}
     chart: {{ template "splunk-kubernetes-objects.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/podSecurityPolicy.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/podSecurityPolicy.yaml
@@ -3,6 +3,7 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "splunk-kubernetes-objects.fullname" . }}
+  namespace: {{ template "splunk-kubernetes-objects.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-objects.name" . }}
     chart: {{ template "splunk-kubernetes-objects.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/secret.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "splunk-kubernetes-objects.secret" . }}
+  namespace: {{ template "splunk-kubernetes-objects.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-objects.name" . }}
     chart: {{ template "splunk-kubernetes-objects.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/serviceAccount.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/serviceAccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "splunk-kubernetes-objects.serviceAccountName" . }}
+  namespace: {{ template "splunk-kubernetes-objects.namespace" . }}
   labels:
     app: {{ template "splunk-kubernetes-objects.name" . }}
     chart: {{ template "splunk-kubernetes-objects.chart" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
@@ -13,6 +13,9 @@
 # Default value: "info"
 logLevel:
 
+# Namespace to deploy agent in (Optional: Will default to release namespace)
+namespace:
+
 rbac:
   # Specifies whether RBAC resources should be created.
   # This should be set to `false` if either:

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -83,6 +83,9 @@ splunk-kubernetes-logging:
   # * error
   logLevel:
 
+  # Namespace to deploy agent in (Optional: Will default to release namespace)
+  namespace:
+
   # This is can be used to exclude verbose logs including various system and Helm/Tiller related logs.
   fluentd:
     # path of logfiles, default /var/log/containers/*.log
@@ -577,6 +580,9 @@ splunk-kubernetes-objects:
   # * error
   logLevel:
 
+  # Namespace to deploy agent in (Optional: Will default to release namespace)
+  namespace:
+
   rbac:
     # Specifies whether RBAC resources should be created.
     # This should be set to `false` if either:
@@ -890,6 +896,9 @@ splunk-kubernetes-metrics:
   # * warn
   # * error
   logLevel:
+
+  # Namespace to deploy agent in (Optional: Will default to release namespace)
+  namespace:
 
   rbac:
     # Specifies whether RBAC resources should be created.


### PR DESCRIPTION
## Proposed changes

Currently, almost all resources being supplied by these charts are defaulting to `.Release.Namespace`. This is generally fine, but it's not configurable, and it doesn't support Gitops because `helm template` does not add `.Release.Namespace` for manifests (https://github.com/helm/helm/issues/3553). The result is that if you try to create the manifests and then apply them without using `helm install`, everything will be put in the `default` namespace

This makes `Namespace` explicit on all relevant resources.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

