### PR TITLE
helm-chart: add support for image digest

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/_helpers.tpl
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/_helpers.tpl
@@ -155,7 +155,11 @@ Create the name of the service account to use
 Create the image name
 */}}
 {{- define "splunk-kubernetes-logging.image" -}}
+{{- if contains .Values.image.tag "sha256" -}}
+{{- printf "%s/%s@%s" .Values.image.registry .Values.image.name .Values.image.tag -}}
+{{- else -}}
 {{- printf "%s/%s:%s" .Values.image.registry .Values.image.name .Values.image.tag -}}
+{{- end -}}
 {{- end -}}
 
 {{/*  evaluate field consume_chunk_on_4xx_errors */}}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/_helpers.tpl
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/_helpers.tpl
@@ -57,13 +57,21 @@ Create the name of the service account to use
 Create the image name
 */}}
 {{- define "splunk-kubernetes-metrics.image" -}}
+{{- if contains .Values.image.tag "sha256" -}}
+{{- printf "%s/%s@%s" .Values.image.registry .Values.image.name .Values.image.tag -}}
+{{- else -}}
 {{- printf "%s/%s:%s" .Values.image.registry .Values.image.name .Values.image.tag -}}
+{{- end -}}
 {{- end -}}
 {{/*
 Create the aggregate image name
 */}}
 {{- define "splunk-kubernetes-metrics.imageAgg" -}}
+{{- if contains .Values.imageAgg.tag "sha256" -}}
+{{- printf "%s/%s@%s" .Values.imageAgg.registry .Values.imageAgg.name .Values.imageAgg.tag -}}
+{{- else -}}
 {{- printf "%s/%s:%s" .Values.imageAgg.registry .Values.imageAgg.name .Values.imageAgg.tag -}}
+{{- end -}}
 {{- end -}}
 
 {{/*  evaluate field consume_chunk_on_4xx_errors */}}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/_helpers.tpl
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/_helpers.tpl
@@ -86,7 +86,11 @@ Rules:
 Create the image name
 */}}
 {{- define "splunk-kubernetes-objects.image" -}}
+{{- if contains .Values.image.tag "sha256" -}}
+{{- printf "%s/%s@%s" .Values.image.registry .Values.image.name .Values.image.tag -}}
+{{- else -}}
 {{- printf "%s/%s:%s" .Values.image.registry .Values.image.name .Values.image.tag -}}
+{{- end -}}
 {{- end -}}
 
 {{/*  evaluate field consume_chunk_on_4xx_errors */}}


### PR DESCRIPTION
## Proposed changes

Add support for image digest under `image.tag`.

Issue: https://github.com/splunk/splunk-connect-for-kubernetes/issues/793

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

