### PR TITLE
Added support for fluentd bufferChunkKeys in logging-pod (fixes #765)

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -466,7 +466,7 @@ data:
         app_name {{ .Chart.Name }}
         app_version {{ .Chart.Version }}
         {{- with .Values.buffer }}
-        <buffer>
+        <buffer {{ join "," $.Values.bufferChunkKeys }}>
         {{- range $parameter, $value := . }}
           {{ $parameter }} {{ $value }}
         {{- end }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -365,6 +365,8 @@ resources:
   # All buffer parameters (except Argument) defined in
   # https://docs.fluentd.org/v1.0/articles/buffer-section#parameters
   # can be configured here.
+bufferChunkKeys:
+  - index
 buffer:
   "@type": memory
   total_limit_size: 600m

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -444,6 +444,8 @@ splunk-kubernetes-logging:
   # All buffer parameters (except Argument) defined in
   # https://docs.fluentd.org/v1.0/articles/buffer-section#parameters
   # can be configured here.
+  bufferChunkKeys:
+  - index
   buffer:
     "@type": memory
     total_limit_size: 600m


### PR DESCRIPTION
support of bufferChunkKeys added and set index as default bufferChunkKey
this helps to prevent an issue of missing events if a pod starts up with an index that the hec declines.
Without bufferChunkKeys all events are mixed within the same chunks and the whole chunk gets thrown away if hec does not accept it.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

