### PR TITLE
Fixed certificate is ignored when using own secret

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -390,13 +390,13 @@ data:
         hec_token "#{ENV['SPLUNK_HEC_TOKEN']}"
         index_key splunk_index
         insecure_ssl {{ or .Values.splunk.hec.insecureSSL .Values.global.splunk.hec.insecureSSL | default false }}
-        {{- if or .Values.splunk.hec.clientCert .Values.global.splunk.hec.clientCert }}
+        {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.clientCert .Values.global.splunk.hec.clientCert)) (and (ne .Values.secret.create true) .Values.secret.has_client_cert) }}
         client_cert /fluentd/etc/splunk/hec_client_cert
         {{- end }}
-        {{- if or .Values.splunk.hec.clientKey .Values.global.splunk.hec.clientKey }}
+        {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.clientKey .Values.global.splunk.hec.clientKey)) (and (ne .Values.secret.create true) .Values.secret.has_client_key) }}
         client_key /fluentd/etc/splunk/hec_client_key
         {{- end }}
-        {{- if or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile }}
+        {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile)) (and (ne .Values.secret.create true) .Values.secret.has_ca_file) }}
         ca_file /fluentd/etc/splunk/hec_ca_file
         {{- end }}
         {{- else }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -156,6 +156,13 @@ podSecurityPolicy:
 secret:
   create: true
   name:
+  # Ignore follwoing config if create is false 
+  # Enable it if secret has hec_client_key
+  has_client_key: false
+  # Enable it if secret has hec_client_cert
+  has_client_cert: false
+  # Enable it if secret has hec_ca_file
+  has_ca_file: false
 
 # Set to true, to change the encoding of all strings to utf-8.
 #

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/configMap.yaml
@@ -147,13 +147,13 @@ data:
       source ${tag}
       sourcetype kube:metrics
       insecure_ssl {{ or .Values.splunk.hec.insecureSSL .Values.global.splunk.hec.insecureSSL | default false }}
-      {{- if or .Values.splunk.hec.clientCert .Values.global.splunk.hec.clientCert }}
+      {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.clientCert .Values.global.splunk.hec.clientCert)) (and (ne .Values.secret.create true) .Values.secret.has_client_cert) }}
       client_cert /fluentd/etc/splunk/hec_client_cert
       {{- end }}
-      {{- if  or .Values.splunk.hec.clientKey .Values.global.splunk.hec.clientKey }}
+      {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.clientKey .Values.global.splunk.hec.clientKey)) (and (ne .Values.secret.create true) .Values.secret.has_client_key) }}
       client_key /fluentd/etc/splunk/hec_client_key
       {{- end }}
-      {{- if or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile }}
+      {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile)) (and (ne .Values.secret.create true) .Values.secret.has_ca_file) }}
       ca_file /fluentd/etc/splunk/hec_ca_file
       {{- end }}
       app_name {{ .Chart.Name }}
@@ -199,13 +199,13 @@ data:
         {{- end }}
       </fields>
       insecure_ssl {{ or .Values.splunk.hec.insecureSSL .Values.global.splunk.hec.insecureSSL | default false }}
-      {{- if or .Values.splunk.hec.clientCert .Values.global.splunk.hec.clientCert }}
+      {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.clientCert .Values.global.splunk.hec.clientCert)) (and (ne .Values.secret.create true) .Values.secret.has_client_cert) }}
       client_cert /fluentd/etc/splunk/hec_client_cert
       {{- end }}
-      {{- if  or .Values.splunk.hec.clientKey .Values.global.splunk.hec.clientKey }}
+      {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.clientKey .Values.global.splunk.hec.clientKey)) (and (ne .Values.secret.create true) .Values.secret.has_client_key) }}
       client_key /fluentd/etc/splunk/hec_client_key
       {{- end }}
-      {{- if or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile }}
+      {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile)) (and (ne .Values.secret.create true) .Values.secret.has_ca_file) }}
       ca_file /fluentd/etc/splunk/hec_ca_file
       {{- end }}
       app_name {{ .Chart.Name }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/configMapMetricsAggregator.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/configMapMetricsAggregator.yaml
@@ -139,13 +139,13 @@ data:
       source ${tag}
       sourcetype kube:metrics:agg
       insecure_ssl {{ or .Values.splunk.hec.insecureSSL .Values.global.splunk.hec.insecureSSL | default false }}
-      {{- if or .Values.splunk.hec.clientCert .Values.global.splunk.hec.clientCert }}
+      {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.clientCert .Values.global.splunk.hec.clientCert)) (and (ne .Values.secret.create true) .Values.secret.has_client_cert) }}
       client_cert /fluentd/etc/splunk/hec_client_cert
       {{- end }}
-      {{- if  or .Values.splunk.hec.clientKey .Values.global.splunk.hec.clientKey }}
+      {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.clientKey .Values.global.splunk.hec.clientKey)) (and (ne .Values.secret.create true) .Values.secret.has_client_key) }}
       client_key /fluentd/etc/splunk/hec_client_key
       {{- end }}
-      {{- if or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile }}
+      {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile)) (and (ne .Values.secret.create true) .Values.secret.has_ca_file) }}
       ca_file /fluentd/etc/splunk/hec_ca_file
       {{- end }}
       app_name {{ .Chart.Name }}
@@ -191,13 +191,13 @@ data:
         {{- end }}
       </fields>
       insecure_ssl {{ or .Values.splunk.hec.insecureSSL .Values.global.splunk.hec.insecureSSL | default false }}
-      {{- if or .Values.splunk.hec.clientCert .Values.global.splunk.hec.clientCert }}
+      {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.clientCert .Values.global.splunk.hec.clientCert)) (and (ne .Values.secret.create true) .Values.secret.has_client_cert) }}
       client_cert /fluentd/etc/splunk/hec_client_cert
       {{- end }}
-      {{- if  or .Values.splunk.hec.clientKey .Values.global.splunk.hec.clientKey }}
+      {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.clientKey .Values.global.splunk.hec.clientKey)) (and (ne .Values.secret.create true) .Values.secret.has_client_key) }}
       client_key /fluentd/etc/splunk/hec_client_key
       {{- end }}
-      {{- if or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile }}
+      {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile)) (and (ne .Values.secret.create true) .Values.secret.has_ca_file) }}
       ca_file /fluentd/etc/splunk/hec_ca_file
       {{- end }}
       app_name {{ .Chart.Name }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
@@ -87,6 +87,13 @@ splunk:
 secret:
   create: true
   name:
+  # Ignore follwoing config if create is false 
+  # Enable it if secret has hec_client_key
+  has_client_key: false
+  # Enable it if secret has hec_client_cert
+  has_client_cert: false
+  # Enable it if secret has hec_ca_file
+  has_ca_file: false
 
 # Defines which version of image to use, and how it should be pulled.
 image:

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/configMap.yaml
@@ -145,13 +145,13 @@ data:
       {{- end }}
       {{- end }}
       insecure_ssl {{ or .Values.splunk.hec.insecureSSL .Values.global.splunk.hec.insecureSSL }}
-      {{- if or .Values.splunk.hec.clientCert .Values.global.splunk.hec.clientCert }}
+      {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.clientCert .Values.global.splunk.hec.clientCert)) (and (ne .Values.secret.create true) .Values.secret.has_client_cert) }}
       client_cert /fluentd/etc/splunk/hec_client_cert
       {{- end }}
-      {{- if or .Values.splunk.hec.clientKey .Values.global.splunk.hec.clientKey }}
+      {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.clientKey .Values.global.splunk.hec.clientKey)) (and (ne .Values.secret.create true) .Values.secret.has_client_key) }}
       client_key /fluentd/etc/splunk/hec_client_key
       {{- end }}
-      {{- if or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile }}
+      {{- if or (and (eq .Values.secret.create true) (or .Values.splunk.hec.caFile .Values.global.splunk.hec.caFile)) (and (ne .Values.secret.create true) .Values.secret.has_ca_file) }}
       ca_file /fluentd/etc/splunk/hec_ca_file
       {{- end }}
       <fields>

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
@@ -195,6 +195,13 @@ splunk:
 secret:
   create: true
   name:
+  # Ignore follwoing config if create is false 
+  # Enable it if secret has hec_client_key
+  has_client_key: false
+  # Enable it if secret has hec_client_cert
+  has_client_cert: false
+  # Enable it if secret has hec_ca_file
+  has_ca_file: false
 
 # Defines which version of image to use, and how it should be pulled.
 image:

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -230,6 +230,13 @@ splunk-kubernetes-logging:
   secret:
     create: true
     name:
+    # Ignore follwoing config if create is false 
+    # Enable it if secret has hec_client_key
+    has_client_key: false
+    # Enable it if secret has hec_client_cert
+    has_client_cert: false
+    # Enable it if secret has hec_ca_file
+    has_ca_file: false
 
   # Directory where to read journald logs (docker daemon logs, kubelet logs, and any other specified service logs).
   # Journald will use `/var/log/journal` automagically if the directory exists. For example on OpenShift this 
@@ -772,6 +779,13 @@ splunk-kubernetes-objects:
   secret:
     create: true
     name:
+      # Ignore follwoing config if create is false 
+    # Enable it if secret has hec_client_key
+    has_client_key: false
+    # Enable it if secret has hec_client_cert
+    has_client_cert: false
+    # Enable it if secret has hec_ca_file
+    has_ca_file: false
 
   # Defines which version of image to use, and how it should be pulled.
   image:
@@ -983,6 +997,13 @@ splunk-kubernetes-metrics:
   secret:
     create: true
     name:
+    # Ignore follwoing config if create is false 
+    # Enable it if secret has hec_client_key
+    has_client_key: false
+    # Enable it if secret has hec_client_cert
+    has_client_cert: false
+    # Enable it if secret has hec_ca_file
+    has_ca_file: false
 
   # Defines which version of image to use, and how it should be pulled.
   image:


### PR DESCRIPTION
Added following config when using self-created secrets.
Fixes https://github.com/splunk/splunk-connect-for-kubernetes/issues/805
```yaml
# Create or use existing secret if the name is empty default name is used
secret:
  create: true
  name:
  # Ignore follwoing config if create is false 
  # Enable it if secret has hec_client_key
  has_client_key: false
  # Enable it if secret has hec_client_cert
  has_client_cert: false
  # Enable it if secret has hec_ca_file
  has_ca_file: false
```

Enable the required config according to the keys available in the self-created certificates.