### PR TITLE
bug fix: override index/sourcetype annotation

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -309,7 +309,7 @@ data:
       {{- if eq .Values.containers.logFormatType "cri" }}
       <filter tail.containers.var.log.pods.**>
         @type jq_transformer
-        jq '.record | . + (.source | capture("/var/log/pods/(?<pod_uid>[^/]+)/(?<container_name>[^/]+)/(?<container_retry>[0-9]+).log")) | .sourcetype = ("{{ .Values.sourcetypePrefix }}:container:" + .container_name) | .splunk_index = {{ or .Values.global.splunk.hec.indexName .Values.splunk.hec.indexName | default "main" | quote }}'
+        jq '.record | . + (.source | capture("/var/log/pods/(?<pod_uid>[^/]+)/(?<container_name>[^/]+)/(?<container_retry>[0-9]+).log"))'
       </filter>
       {{- end }}
 


### PR DESCRIPTION
fixed bug that override the "splunk.com/sourcetype" and "splunk.com/index" annotation of Pod.

ref: https://github.com/splunk/splunk-connect-for-kubernetes/issues/827

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply._

- [ ] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [ ] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

