### PR TITLE
Make enable_stat_watcher configurable

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -85,7 +85,7 @@ data:
       pos_file {{ .Values.containers.path }}/splunk-fluentd-containers.log.pos
       path_key source
       read_from_head true
-      enable_stat_watcher false
+      enable_stat_watcher {{ .Values.containers.enableStatWatcher }}
       refresh_interval {{ .Values.containers.refreshInterval | default 60 }}
       <parse>
       {{- if eq .Values.containers.logFormatType "cri" }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -85,6 +85,7 @@ data:
       pos_file {{ .Values.containers.path }}/splunk-fluentd-containers.log.pos
       path_key source
       read_from_head true
+      enable_stat_watcher false
       refresh_interval {{ .Values.containers.refreshInterval | default 60 }}
       <parse>
       {{- if eq .Values.containers.logFormatType "cri" }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/values.yaml
@@ -43,6 +43,9 @@ containers:
   removeBlankEvents: true
   # Boolean if true, uses local time. UTC. Otherwise, UTC is used
   localTime: false
+  # Boolean to whether enables the additional inotify-based watcher.
+  # Setting this parameter to false will disable the inotify events and use only timer watcher for file tailing.
+  enableStatWatcher: true
 
 # Directory where to read journald logs (docker daemon logs, kubelet logs, and any other specified service logs).
 # Journald will use `/var/log/journal` automagically if the directory exists. For example on OpenShift this 

--- a/helm-chart/splunk-connect-for-kubernetes/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/values.yaml
@@ -117,6 +117,9 @@ splunk-kubernetes-logging:
     removeBlankEvents: true
     # Boolean if true, uses local time. UTC. Otherwise, UTC is used
     localTime: false
+    # Boolean to whether enables the additional inotify-based watcher.
+    # Setting this parameter to false will disable the inotify events and use only timer watcher for file tailing.
+    enableStatWatcher: true
 
   # Enriches log record with kubernetes data
   k8sMetadata:

--- a/manifests/splunk-kubernetes-logging/configMap.yaml
+++ b/manifests/splunk-kubernetes-logging/configMap.yaml
@@ -48,6 +48,7 @@ data:
       pos_file /var/log/splunk-fluentd-containers.log.pos
       path_key source
       read_from_head true
+      enable_stat_watcher true
       refresh_interval 60
       <parse>
         @type json


### PR DESCRIPTION

https://docs.fluentd.org/input/tail#in_tail-is-sometimes-stopped-when-monitor-lots-of-files.-how-to-avoid-it
> `in_tail` is sometimes stopped when monitoring lots of files. How to avoid it?
> Try to set `enable_stat_watcher false` in in_tail setting. We got several reports that in_tail is stopped when * is included in path, and the problem is resolved by disabling the inotify events.