### PR TITLE
Remove the 'de_dot' functionality as it is depricated

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-logging/templates/configMap.yaml
@@ -260,7 +260,6 @@ data:
       <filter tail.containers.**>
         @type kubernetes_metadata
         annotation_match [ ".*" ]
-        de_dot false
         watch {{ .Values.k8sMetadata.watch }}
         cache_ttl {{ .Values.k8sMetadata.cache_ttl }}
       </filter>

--- a/manifests/splunk-kubernetes-logging/configMap.yaml
+++ b/manifests/splunk-kubernetes-logging/configMap.yaml
@@ -244,7 +244,6 @@ data:
       <filter tail.containers.**>
         @type kubernetes_metadata
         annotation_match [ ".*" ]
-        de_dot false
         watch true
         cache_ttl 3600
       </filter>


### PR DESCRIPTION
The 'de_dot' functionality is depricated and will be removed from the fluent-plugin-kubernetes_metadata_filter as it was mentioned below in the release_notes.md. 


Found the warning in splunk-logging pods. 
```
2024-01-04 19:35:09 +0000 [info]: init supervisor logger path=nil rotate_age=nil rotate_size=nil
2024-01-04 19:35:10 +0000 [INFO]: Reading bearer token from /var/run/secrets/kubernetes.io/serviceaccount/token
2024-01-04 19:35:11 +0000 [info]: #0 init worker0 logger path=nil rotate_age=nil rotate_size=nil
2024-01-04 19:35:11 +0000 [INFO]: Reading bearer token from /var/run/secrets/kubernetes.io/serviceaccount/token
2024-01-04 19:35:11 +0000 [warn]: parameter 'de_dot' in <filter k8s.**>
  @type kubernetes_metadata
  annotation_match [".*"]
  de_dot false
  watch true
  cache_ttl 3600
</filter> is not used.
```

Review plugin release notes.
```
fluent-plugin-kubernetes_metadata_filter-3.1.0 $ grep de_dot release_notes.md
As of this release, the 'de_dot' functionality is depricated and will be removed in future releases.
```

### Environment:
Splunk-connect 1.5.3
Fluentd 1.15.3
fluent-plugin-kubernetes_metadata_filter 3.1.0

