### PR TITLE
Add the Topologyspreadconstraints to deployments in Helm Chart

### DIFF
--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/templates/deploymentMetricsAggregator.yaml
@@ -55,6 +55,10 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.imageAgg.pullsecretName}}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: 
+{{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: splunk-fluentd-k8s-metrics-agg
         image: {{ template "splunk-kubernetes-metrics.imageAgg" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-metrics/values.yaml
@@ -207,6 +207,18 @@ priorityClassNameAgg:
 # Defines node affinity to restrict pod deployment.
 affinity: {}
 
+# Defines topologySpreadConstraints to restrict pod deployment.
+topologySpreadConstraints: []
+#- maxSkew: 1
+#  topologyKey: topology.kubernetes.io/zone
+#  whenUnsatisfiable: DoNotSchedule
+#  labelSelector:
+#    matchExpressions:
+#    - key: component
+#      operator: In
+#      values:
+#      - aggregator
+
 # = Kubernetes Connection Configs =
 kubernetes:
   # The hostname or IP address that kubelet will use to connect to. If not supplied, status.hostIP of the node is used to fetch metrics from the Kubelet API (via the $KUBERNETES_NODE_IP environment variable).

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/deployment.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/templates/deployment.yaml
@@ -53,6 +53,10 @@ spec:
       imagePullSecrets:
       - name: {{ .Values.image.pullSecretName }}
       {{ end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: 
+{{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: splunk-fluentd-k8s-objects
         image: {{ template "splunk-kubernetes-objects.image" . }}

--- a/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
+++ b/helm-chart/splunk-connect-for-kubernetes/charts/splunk-kubernetes-objects/values.yaml
@@ -259,6 +259,18 @@ tolerations: []
 # Defines node affinity to restrict pod deployment.
 affinity: {}
 
+# Defines topologySpreadConstraints to restrict pod deployment.
+topologySpreadConstraints: []
+#- maxSkew: 1
+#  topologyKey: topology.kubernetes.io/zone
+#  whenUnsatisfiable: DoNotSchedule
+#  labelSelector:
+#    matchExpressions:
+#    - key: app
+#      operator: In
+#      values:
+#      - splunk-kubernetes-objects
+
 # `customFilters` defines the custom filters to be used.
 # This section can be used to define custom filters using plugins like https://github.com/splunk/fluent-plugin-jq
 # Its also possible to use other filters like https://www.fluentd.org/plugins#filter


### PR DESCRIPTION
## Proposed changes
I would like to add Topologyspreadconstraint to deployments in the Helm Chart:

```
topologySpreadConstraints:
- maxSkew: 1
  topologyKey: topology.kubernetes.io/zone
  whenUnsatisfiable: DoNotSchedule
  labelSelector:
    matchExpressions:
    - key: app
      operator: In
      values:
      - {{ template "splunk-kubernetes-metrics.name" . }}
```
The issue link: [873](https://github.com/splunk/splunk-connect-for-kubernetes/issues/873)
## Types of changes

What types of changes does your code introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CONTRIBUTING.md) doc
- [x] I have read the [CLA](https://github.com/splunk/splunk-connect-for-kubernetes/blob/develop/CLA.md)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

