### PR TITLE
archive message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# End of Support
+# End of Support and Repository Archive
 
-**Important:** The Splunk Connect for Kubernetes will reach End of Support on *January 1, 2024*. After that date, this repository will no longer receive updates from Splunk and will no longer be supported by Splunk. Until then, only critical security fixes and bug fixes will be provided. Splunk recommends migrating to [Splunk OpenTelemetry Collector for Kubernetes](https://github.com/signalfx/splunk-otel-collector-chart). Please refer to this [migration guide](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/migration-from-sck.md) for more details.
+**Important:** Splunk Connect for Kubernetes reached End of Support on *January 1, 2024*. This repository has been archived and is read-only. It no longer receives updates from Splunk and is no longer supported by Splunk. Splunk recommends migrating to [Splunk OpenTelemetry Collector for Kubernetes](https://github.com/signalfx/splunk-otel-collector-chart). Please refer to this [migration guide](https://github.com/signalfx/splunk-otel-collector-chart/blob/main/docs/migration-from-sck.md) for more details.
 
 # What does Splunk Connect for Kubernetes do?
 


### PR DESCRIPTION
This pull request updates the `README.md` file to reflect the current status of the project. The main change clarifies that the Splunk Connect for Kubernetes repository is now archived, read-only, and no longer supported, as the end of support date has passed.

Repository status update:

* Updated the introductory section to state that Splunk Connect for Kubernetes reached end of support on January 1, 2024, and that the repository is now archived and read-only, replacing previous language about future end of support.

